### PR TITLE
feat: add version info API

### DIFF
--- a/futurex_openedx_extensions/__init__.py
+++ b/futurex_openedx_extensions/__init__.py
@@ -1,3 +1,3 @@
 """One-line description for README and other doc files."""
 
-__version__ = '0.3.7'
+__version__ = "0.3.8"

--- a/futurex_openedx_extensions/dashboard/urls.py
+++ b/futurex_openedx_extensions/dashboard/urls.py
@@ -23,4 +23,5 @@ urlpatterns = [
     ),
     re_path(r'^api/fx/statistics/v1/course_statuses/$', views.CourseStatusesView.as_view(), name='course-statuses'),
     re_path(r'^api/fx/statistics/v1/total_counts/$', views.TotalCountsView.as_view(), name='total-counts'),
+    re_path(r'^api/fx/version/v1/info/$', views.VersionInfoView.as_view(), name='version-info'),
 ]

--- a/futurex_openedx_extensions/dashboard/views.py
+++ b/futurex_openedx_extensions/dashboard/views.py
@@ -14,7 +14,7 @@ from futurex_openedx_extensions.helpers.constants import COURSE_STATUS_SELF_PREF
 from futurex_openedx_extensions.helpers.converters import error_details_to_dictionary
 from futurex_openedx_extensions.helpers.filters import DefaultOrderingFilter
 from futurex_openedx_extensions.helpers.pagination import DefaultPagination
-from futurex_openedx_extensions.helpers.permissions import HasTenantAccess
+from futurex_openedx_extensions.helpers.permissions import HasTenantAccess, IsSystemStaff
 from futurex_openedx_extensions.helpers.tenants import get_selected_tenants, get_user_id_from_username_tenants
 
 
@@ -205,3 +205,17 @@ class LearnerCoursesView(APIView):
         return Response(serializers.LearnerCoursesDetailsSerializer(
             courses, context={'request': request}, many=True
         ).data)
+
+
+class VersionInfoView(APIView):
+    """View to get the version information"""
+    permission_classes = [IsSystemStaff]
+
+    def get(self, request, *args, **kwargs):  # pylint: disable=no-self-use
+        """
+        GET /api/fx/version/v1/info/
+        """
+        import futurex_openedx_extensions  # pylint: disable=import-outside-toplevel
+        return JsonResponse({
+            'version': futurex_openedx_extensions.__version__,
+        })

--- a/futurex_openedx_extensions/helpers/permissions.py
+++ b/futurex_openedx_extensions/helpers/permissions.py
@@ -21,3 +21,16 @@ class HasTenantAccess(IsAuthenticated):
                 raise PermissionDenied(detail=json.dumps(details))
 
         return True
+
+
+class IsSystemStaff(IsAuthenticated):
+    """Permission class to check if the user is a staff member."""
+    def has_permission(self, request, view):
+        """Check if the user is a staff member"""
+        if not super().has_permission(request, view):
+            raise NotAuthenticated()
+
+        if not request.user.is_staff and not request.user.is_superuser:
+            raise PermissionDenied(detail=json.dumps({"reason": "User is not a system staff member"}))
+
+        return True

--- a/tests/base_test_data.py
+++ b/tests/base_test_data.py
@@ -85,7 +85,7 @@ _base_data = {
             "config_id": 8,
         },
     },
-    "users_count": 55,
+    "users_count": 60,
     "user_signup_source__users": {
         "s1.sample.com": [1, 2, 3, 4, 5],
         "s2.sample.com": [4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
@@ -173,8 +173,8 @@ _base_data = {
             2: [23, 52, 53, 54],
         },
     },
-    "super_users": [1],
-    "staff_users": [2],
+    "super_users": [1, 60],
+    "staff_users": [2, 60],
     "course_access_roles": {  # roles, user ids per org
         "staff": {  # at least one role that is not in TENANT_LIMITED_ADMIN_ROLES
             "ORG1": [3],

--- a/tests/test_base_test_data.py
+++ b/tests/test_base_test_data.py
@@ -18,3 +18,49 @@ def test_certificate_must_be_enrolled():
                 assert user_id in _base_data['course_enrollments'].get(org, {}).get(course_id, []), (
                     f'User {user_id} is not enrolled in course {course_id} of org {org}'
                 )
+
+
+def test_staff_only():
+    """Verify the list of users having is_staff set to True, but not is_superuser"""
+    valid_list = [2]
+    for user_id in _base_data["staff_users"]:
+        if user_id in valid_list:
+            assert user_id not in _base_data["super_users"], \
+                f"User (user{user_id}) must be a staff user, but not a super user"
+            valid_list.remove(user_id)
+        else:
+            assert user_id in _base_data["super_users"], \
+                f"User (user{user_id}) must not be a staff user, or must be both a staff and a super user"
+
+    assert not valid_list, f"These users must be staff users, but not found in the staff_users list: {valid_list}"
+
+
+def test_super_only():
+    """Verify the list of users having is_superuser set to True"""
+    valid_list = [1]
+    for user_id in _base_data["super_users"]:
+        if user_id in valid_list:
+            assert user_id not in _base_data["staff_users"], \
+                f"User (user{user_id}) must be a super user, but not a staff user"
+            valid_list.remove(user_id)
+        else:
+            assert user_id in _base_data["staff_users"], \
+                f"User (user{user_id}) must not be a super user, or must be both a staff and a super user"
+
+    assert not valid_list, f"These users must be super users, but not found in the super_users list: ({valid_list})"
+
+
+def test_both_staff_and_super():
+    """Verify the list of users having both is_staff and is_superuser set to True"""
+    valid_list = [60]
+    for user_id in _base_data["super_users"]:
+        if user_id in valid_list:
+            assert user_id in _base_data["staff_users"], \
+                f"User (user{user_id}) must be both a staff and a super user"
+            valid_list.remove(user_id)
+        else:
+            assert user_id not in _base_data["staff_users"], \
+                f"User (user{user_id}) must not be both a staff and a super user"
+
+    assert not valid_list, \
+        f"These users must be both a staff and a super user, but not found in the super_users list: {valid_list}"


### PR DESCRIPTION
feat: add version info API

The deployment process on staging and production is a bit complicated in terms of tracing deployed parts. Adding this API to easily check the deployed extensions version

```
GET /api/fx/version/v1/info/
```

allowed for only staff and super users. Result:
```json
{
  "version": "0.3.8"
}
```