### PR TITLE
fix: some queries include inactive enrollments

### DIFF
--- a/futurex_openedx_extensions/__init__.py
+++ b/futurex_openedx_extensions/__init__.py
@@ -1,3 +1,3 @@
 """One-line description for README and other doc files."""
 
-__version__ = '0.5.5'
+__version__ = '0.5.6'

--- a/futurex_openedx_extensions/dashboard/details/learners.py
+++ b/futurex_openedx_extensions/dashboard/details/learners.py
@@ -41,6 +41,7 @@ def get_courses_count_for_learner_queryset(
                 visible_filter=visible_courses_filter,
                 active_filter=active_courses_filter,
             )) &
+            Q(courseenrollment__is_active=True) &
             ~Exists(
                 CourseAccessRole.objects.filter(
                     user_id=OuterRef('id'),
@@ -183,7 +184,8 @@ def get_learners_by_course_queryset(course_id: str, search_text: str | None = No
     """
     queryset = get_learners_search_queryset(search_text)
     queryset = queryset.filter(
-        courseenrollment__course_id=course_id
+        courseenrollment__course_id=course_id,
+        courseenrollment__is_active=True,
     ).filter(
         ~Exists(
             CourseAccessRole.objects.filter(

--- a/tests/base_test_data.py
+++ b/tests/base_test_data.py
@@ -10,7 +10,7 @@ _base_data = {
                 'IS_FX_DASHBOARD_ENABLED': True,
             },
         },
-        2: {  # Organisation is duplicated with tenant 7
+        2: {  # Organisation is duplicated with tenant 7 and 8
             'lms_configs': {
                 'LMS_BASE': 's2.sample.com',
                 'course_org_filter': ['ORG3', 'ORG8'],

--- a/tests/test_dashboard/test_details/test_details_courses.py
+++ b/tests/test_dashboard/test_details/test_details_courses.py
@@ -53,6 +53,22 @@ def test_get_courses_queryset_result_excludes_staff(base_data, fx_permission_inf
 
 
 @pytest.mark.django_db
+def test_get_courses_queryset_result_excludes_staff_inactive_enrollment(
+    base_data, fx_permission_info
+):  # pylint: disable=unused-argument
+    """Verify that enrolled_count of get_courses_queryset is not including inactive enrollments."""
+    enrollment = CourseEnrollment.objects.get(user_id=21, course_id='course-v1:ORG1+5+5')
+    assert enrollment.is_active is True, 'bad test data'
+    queryset = get_courses_queryset(fx_permission_info).filter(id='course-v1:ORG1+5+5')
+    assert queryset.count() == 1, 'bad test data'
+    assert queryset.first().enrolled_count == 3, 'bad test data'
+
+    enrollment.is_active = False
+    enrollment.save()
+    assert get_courses_queryset(fx_permission_info).filter(id='course-v1:ORG1+5+5').first().enrolled_count == 2
+
+
+@pytest.mark.django_db
 def test_get_courses_queryset_result_rating(base_data, fx_permission_info):  # pylint: disable=unused-argument
     """Verify that get_courses_queryset returns the correct rating."""
     ratings = [3, 4, 5, 3, 4, 5, 3, 2, 5, 2, 4, 5]

--- a/tests/test_dashboard/test_details/test_details_learners.py
+++ b/tests/test_dashboard/test_details/test_details_learners.py
@@ -2,7 +2,7 @@
 from unittest.mock import patch
 
 import pytest
-from common.djangoapps.student.models import UserProfile
+from common.djangoapps.student.models import CourseEnrollment, UserProfile
 from django.contrib.auth import get_user_model
 from lms.djangoapps.grades.models import PersistentCourseGrade
 
@@ -46,7 +46,23 @@ def test_count_for_learner_queryset(
         result=fnc(fx_permission_info)
     )
 
-    assert queryset.all()[0].result == expected_count, f'{assert_error_message}. Check the test data for details.'
+    assert queryset.first().result == expected_count, f'{assert_error_message}. Check the test data for details.'
+
+
+@pytest.mark.django_db
+def test_get_courses_count_for_learner_queryset_inactive_enrollment(
+    base_data, fx_permission_info
+):  # pylint: disable=unused-argument
+    """Verify that get_courses_count_for_learner_queryset returns the correct QuerySet for inactive enrollments."""
+    user_id = 5
+    queryset = get_user_model().objects.filter(id=user_id).annotate(
+        result=get_courses_count_for_learner_queryset(fx_permission_info)
+    )
+    assert queryset.first().result == 2, 'bad test data, user5 should have 2 enrollments'
+    enrollment = CourseEnrollment.objects.filter(user_id=5).first()
+    enrollment.is_active = False
+    enrollment.save()
+    assert queryset.first().result == 1, 'inactive enrollments should be counted'
 
 
 @pytest.mark.django_db
@@ -134,11 +150,16 @@ def test_get_learners_queryset(
 @pytest.mark.django_db
 def test_get_learners_by_course_queryset(base_data):  # pylint: disable=unused-argument
     """Verify that get_learners_by_course_queryset returns the correct QuerySet."""
+    PersistentCourseGrade.objects.create(user_id=15, course_id='course-v1:ORG1+5+5', percent_grade=0.67)
     queryset = get_learners_by_course_queryset('course-v1:ORG1+5+5')
     assert queryset.count() == 3, 'unexpected test data'
-    PersistentCourseGrade.objects.create(user_id=15, course_id='course-v1:ORG1+5+5', percent_grade=0.67)
-    assert queryset.first().certificate_available is not None, 'certificate_available should be in the queryset'
-    assert queryset.first().course_score == 0.67, \
+
+    user15 = queryset.filter(id=15).first()
+    assert user15.certificate_available is not None, 'certificate_available should be in the queryset'
+    assert user15.course_score == 0.67, \
         'course_score should be in the queryset with value 0.67 for the first record (user15)'
-    assert queryset.first().active_in_course is False, \
+    assert user15.active_in_course is False, \
         'active_in_course should be in the queryset with value True for the first record (user15)'
+
+    user15.courseenrollment_set.update(is_active=False)
+    assert get_learners_by_course_queryset('course-v1:ORG1+5+5').count() == 2, 'inactive enrollments should be counted'

--- a/tests/test_dashboard/test_statistics/test_learners.py
+++ b/tests/test_dashboard/test_statistics/test_learners.py
@@ -2,6 +2,7 @@
 from unittest.mock import Mock
 
 import pytest
+from common.djangoapps.student.models import CourseEnrollment, UserSignupSource
 
 from futurex_openedx_extensions.dashboard.statistics import learners
 
@@ -31,6 +32,28 @@ def test_get_learners_count_having_enrollment_per_org(
 
 
 @pytest.mark.django_db
+def test_get_learners_count_having_enrollment_per_org_inactive_enrollment(
+    base_data, user1_fx_permission_info
+):  # pylint: disable=unused-argument
+    """Verify that inactive enrollments are not counted by get_learners_count_having_enrollment_per_org."""
+    enrollment = CourseEnrollment.objects.get(user_id=21, course_id='course-v1:ORG1+5+5')
+    assert enrollment.is_active is True, 'bad test data'
+    tenant1_org1 = learners.get_learners_count_having_enrollment_per_org(
+        user1_fx_permission_info, 1
+    )
+    assert tenant1_org1[0]['org'] == 'ORG1', 'bad test data'
+    assert tenant1_org1[0]['learners_count'] == 4, 'bad test data'
+
+    enrollment.is_active = False
+    enrollment.save()
+    tenant1_org1 = learners.get_learners_count_having_enrollment_per_org(
+        user1_fx_permission_info, 1
+    )
+    assert tenant1_org1[0]['org'] == 'ORG1', 'bad test data'
+    assert tenant1_org1[0]['learners_count'] == 3, 'inactive enrollment should not be counted'
+
+
+@pytest.mark.django_db
 @pytest.mark.parametrize('tenant_id, expected_result', [
     (1, 17),
     (2, 16),
@@ -47,6 +70,22 @@ def test_get_learners_count_having_enrollment_for_tenant(
     """Test get_learners_count_having_enrollment_for_tenant function."""
     result = learners.get_learners_count_having_enrollment_for_tenant(user1_fx_permission_info, tenant_id)
     assert result == expected_result, f'Wrong learners count: {result} for tenant: {tenant_id}'
+
+
+@pytest.mark.django_db
+def test_get_learners_count_having_enrollment_for_tenant_inactive_enrollment(
+    base_data, user1_fx_permission_info
+):  # pylint: disable=unused-argument
+    """Verify that get_learners_count_having_enrollment_for_tenant is not counting inactive enrollments."""
+    enrollments = CourseEnrollment.objects.filter(user_id=21, course__org__in=['ORG1', 'ORG2'])
+    assert enrollments.filter(is_active=True).count() == 3, 'bad test data'
+    assert enrollments.filter(is_active=False).count() == 0, 'bad test data'
+    assert learners.get_learners_count_having_enrollment_for_tenant(user1_fx_permission_info, 1) == 17, \
+        'bad test data'
+
+    enrollments.update(is_active=False)
+    assert learners.get_learners_count_having_enrollment_for_tenant(user1_fx_permission_info, 1) == 16, \
+        'inactive enrollment should not be counted'
 
 
 @pytest.mark.django_db
@@ -88,6 +127,35 @@ def test_get_learners_count_having_no_enrollment_without_full_access_to_tenant()
         'view_allowed_course_access_orgs': ['ORG8'],
     })
     assert learners.get_learners_count_having_no_enrollment(fx_permission_info, tenant_id) == 0
+
+
+@pytest.mark.django_db
+def test_get_learners_count_having_no_enrollment_inactive_enrollment(
+    base_data, user1_fx_permission_info
+):  # pylint: disable=unused-argument
+    """Verify that get_learners_count_having_no_enrollment is counting inactive enrollments correctly."""
+    user_id = 5
+    enrollments = CourseEnrollment.objects.filter(user_id=user_id, course__org__in=['ORG1', 'ORG2'])
+    signup = UserSignupSource.objects.filter(user_id=user_id, site='s1.sample.com')
+    assert enrollments.filter(is_active=True).count() == 2, 'bad test data'
+    assert enrollments.filter(is_active=False).count() == 0, 'bad test data'
+    assert signup.count() == 1, 'bad test data'
+    assert learners.get_learners_count_having_no_enrollment(user1_fx_permission_info, 1) == 0, 'bad test data'
+
+    enrollment = enrollments.first()
+    enrollment.is_active = False
+    enrollment.save()
+    assert learners.get_learners_count_having_no_enrollment(user1_fx_permission_info, 1) == 0, \
+        'having inactive enrollments should not include the user from the count if there are other active enrollments'
+
+    enrollments.update(is_active=False)
+    assert learners.get_learners_count_having_no_enrollment(user1_fx_permission_info, 1) == 1, \
+        'users with at least one inactive enrollment, and no active enrollments should be counted'
+
+    signup.delete()
+    assert learners.get_learners_count_having_no_enrollment(user1_fx_permission_info, 1) == 1, \
+        'users with at least one inactive enrollment, and no active enrollments '\
+        'should be counted even if they have no signup source'
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Enrollments with `is_active` set to `False` must be excluded from all calculations and results. Except for checking if a user is related to a certain tenant or not

