### PR TITLE
feat: global courses rating API

### DIFF
--- a/futurex_openedx_extensions/__init__.py
+++ b/futurex_openedx_extensions/__init__.py
@@ -1,3 +1,3 @@
 """One-line description for README and other doc files."""
 
-__version__ = '0.6.1'
+__version__ = '0.6.3'

--- a/futurex_openedx_extensions/__init__.py
+++ b/futurex_openedx_extensions/__init__.py
@@ -1,3 +1,3 @@
 """One-line description for README and other doc files."""
 
-__version__ = '0.6.3'
+__version__ = '0.6.4'

--- a/futurex_openedx_extensions/dashboard/statistics/courses.py
+++ b/futurex_openedx_extensions/dashboard/statistics/courses.py
@@ -1,10 +1,11 @@
 """functions for getting statistics about courses"""
 from __future__ import annotations
 
-from django.db.models import Case, CharField, Count, Q, Value, When
+from django.db.models import Case, CharField, Count, Q, Sum, Value, When
 from django.db.models.query import QuerySet
 from django.utils.timezone import now
 
+from futurex_openedx_extensions.dashboard.details.courses import annotate_courses_rating_queryset
 from futurex_openedx_extensions.helpers.constants import COURSE_STATUSES
 from futurex_openedx_extensions.helpers.querysets import get_base_queryset_courses
 
@@ -68,5 +69,65 @@ def get_courses_count_by_status(
     ).values('status', 'self_paced').annotate(
         courses_count=Count('id')
     ).values('status', 'self_paced', 'courses_count')
+
+    return q_set
+
+
+def get_courses_ratings(
+    fx_permission_info: dict,
+    visible_filter: bool | None = True,
+    active_filter: bool | None = None,
+) -> QuerySet:
+    """
+    Get the average rating of courses in the given tenants
+
+    :param fx_permission_info: Dictionary containing permission information
+    :type fx_permission_info: dict
+    :param visible_filter: Value to filter courses on catalog visibility. None means no filter
+    :type visible_filter: bool | None
+    :param active_filter: Value to filter courses on active status. None means no filter (according to dates)
+    :type active_filter: bool | None
+    :return: QuerySet of average rating per organization
+    :rtype: QuerySet
+    """
+    q_set = get_base_queryset_courses(
+        fx_permission_info, visible_filter=visible_filter, active_filter=active_filter
+    )
+
+    q_set = annotate_courses_rating_queryset(q_set).filter(rating_count__gt=0)
+    # annotate the count of all records with FeedbackCourse rating equal 1 using subquery on FeedbackCourse
+    q_set = q_set.annotate(
+        course_rating_1_count=Count(
+            'feedbackcourse',
+            filter=Q(feedbackcourse__rating_content=1)
+        ),
+        course_rating_2_count=Count(
+            'feedbackcourse',
+            filter=Q(feedbackcourse__rating_content=2)
+        ),
+        course_rating_3_count=Count(
+            'feedbackcourse',
+            filter=Q(feedbackcourse__rating_content=3)
+        ),
+        course_rating_4_count=Count(
+            'feedbackcourse',
+            filter=Q(feedbackcourse__rating_content=4)
+        ),
+        course_rating_5_count=Count(
+            'feedbackcourse',
+            filter=Q(feedbackcourse__rating_content=5)
+        ),
+    )
+
+    q_set = q_set.aggregate(
+        total_rating=Sum('rating_total'),
+        total_count=Sum('rating_count'),
+        courses_count=Count('id'),
+        rating_1_count=Sum('course_rating_1_count'),
+        rating_2_count=Sum('course_rating_2_count'),
+        rating_3_count=Sum('course_rating_3_count'),
+        rating_4_count=Sum('course_rating_4_count'),
+        rating_5_count=Sum('course_rating_5_count'),
+    )
 
     return q_set

--- a/futurex_openedx_extensions/dashboard/urls.py
+++ b/futurex_openedx_extensions/dashboard/urls.py
@@ -30,6 +30,7 @@ urlpatterns = [
         name='learner-courses'
     ),
     re_path(r'^api/fx/statistics/v1/course_statuses/$', views.CourseStatusesView.as_view(), name='course-statuses'),
+    re_path(r'^api/fx/statistics/v1/rating/$', views.GlobalRatingView.as_view(), name='statistics-rating'),
     re_path(r'^api/fx/statistics/v1/total_counts/$', views.TotalCountsView.as_view(), name='total-counts'),
     re_path(
         fr'^api/fx/query/v1/(?P<scope>{QUERY_ALLOWED_SCOPES})/(?P<slug>{CLICKHOUSE_QUERY_SLUG_PATTERN})/$',

--- a/futurex_openedx_extensions/dashboard/views.py
+++ b/futurex_openedx_extensions/dashboard/views.py
@@ -21,7 +21,11 @@ from futurex_openedx_extensions.dashboard.details.learners import (
     get_learners_queryset,
 )
 from futurex_openedx_extensions.dashboard.statistics.certificates import get_certificates_count
-from futurex_openedx_extensions.dashboard.statistics.courses import get_courses_count, get_courses_count_by_status
+from futurex_openedx_extensions.dashboard.statistics.courses import (
+    get_courses_count,
+    get_courses_count_by_status,
+    get_courses_ratings,
+)
 from futurex_openedx_extensions.dashboard.statistics.learners import get_learners_count
 from futurex_openedx_extensions.helpers import clickhouse_operations as ch
 from futurex_openedx_extensions.helpers.constants import (
@@ -64,7 +68,7 @@ class TotalCountsView(APIView, FXViewRoleInfoMixin):
         STAT_CERTIFICATES: 'certificates_count',
         STAT_COURSES: 'courses_count',
         STAT_HIDDEN_COURSES: 'hidden_courses_count',
-        STAT_LEARNERS: 'learners_count'
+        STAT_LEARNERS: 'learners_count',
     }
 
     permission_classes = [FXHasTenantCourseAccess]
@@ -319,6 +323,33 @@ class LearnersDetailsForCourseView(ListAPIView, FXViewRoleInfoMixin):
             course_id=course_id,
             search_text=search_text,
         )
+
+
+class GlobalRatingView(APIView, FXViewRoleInfoMixin):
+    """View to get the global rating"""
+    permission_classes = [FXHasTenantCourseAccess]
+    fx_view_name = 'global_rating'
+    fx_default_read_only_roles = ['staff', 'instructor', 'data_researcher', 'org_course_creator_group']
+    fx_view_description = 'api/fx/statistics/v1/rating/: Get the global rating for courses'
+
+    def get(self, request: Any, *args: Any, **kwargs: Any) -> JsonResponse:
+        """
+        GET /api/fx/statistics/v1/rating/?tenant_ids=<tenantIds>
+
+        <tenantIds> (optional): a comma-separated list of the tenant IDs to get the information for. If not provided,
+            the API will assume the list of all accessible tenants by the user
+        """
+        data_result = get_courses_ratings(fx_permission_info=self.fx_permission_info)
+        result = {
+            'total_rating': data_result['total_rating'],
+            'total_count': sum(data_result[f'rating_{index}_count'] for index in range(1, 6)),
+            'courses_count': data_result['courses_count'],
+            'rating_counts': {
+                str(index): data_result[f'rating_{index}_count'] for index in range(1, 6)
+            },
+        }
+
+        return JsonResponse(result)
 
 
 class ClickhouseQueryView(APIView, FXViewRoleInfoMixin):

--- a/tests/test_dashboard/test_views.py
+++ b/tests/test_dashboard/test_views.py
@@ -6,6 +6,7 @@ import ddt
 import pytest
 from common.djangoapps.student.models import CourseAccessRole
 from django.contrib.auth import get_user_model
+from django.core.exceptions import ValidationError
 from django.core.paginator import EmptyPage
 from django.http import JsonResponse
 from django.urls import resolve, reverse
@@ -720,6 +721,7 @@ class TestClickhouseQueryView(MockPatcherMixin, BaseTestViewMixin):
     @ddt.data(
         ch.ClickhouseBaseError,
         ValueError,
+        ValidationError,
     )
     def test_bad_use_of_arguments(self, side_effect):
         """Verify that the view returns 400 when there is a bad use of arguments"""

--- a/tests/test_dashboard/test_views.py
+++ b/tests/test_dashboard/test_views.py
@@ -569,6 +569,57 @@ class MockClickhouseQuery:
         )
 
 
+class TestGlobalRatingView(BaseTestViewMixin):
+    """Tests for GlobalRatingView"""
+    VIEW_NAME = 'fx_dashboard:statistics-rating'
+
+    def test_unauthorized(self):
+        """Verify that the view returns 403 when the user is not authenticated"""
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 403)
+
+    def test_permission_classes(self):
+        """Verify that the view has the correct permission classes"""
+        view_func, _, _ = resolve(self.url)
+        view_class = view_func.view_class
+        self.assertEqual(view_class.permission_classes, [FXHasTenantCourseAccess])
+
+    def test_success(self):
+        """Verify that the view returns the correct response"""
+        self.login_user(self.staff_user)
+        test_data = {
+            'total_rating': 50,
+            'courses_count': 2,
+            'rating_1_count': 3,
+            'rating_2_count': 5,
+            'rating_3_count': 2,
+            'rating_4_count': 1,
+            'rating_5_count': 4,
+        }
+        expected_result = {
+            'total_rating': 50,
+            'total_count': 15,
+            'courses_count': 2,
+            'rating_counts': {
+                '1': 3,
+                '2': 5,
+                '3': 2,
+                '4': 1,
+                '5': 4,
+            },
+        }
+        for value in range(1, 6):
+            assert expected_result['rating_counts'][str(value)] == test_data[f'rating_{value}_count']
+        assert expected_result['total_count'] == sum(expected_result['rating_counts'].values())
+
+        with patch('futurex_openedx_extensions.dashboard.views.get_courses_ratings') as mocked_calc:
+            mocked_calc.return_value = test_data
+            response = self.client.get(self.url)
+        data = json.loads(response.content)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(data, expected_result)
+
+
 @ddt.ddt
 class TestClickhouseQueryView(MockPatcherMixin, BaseTestViewMixin):
     """Tests for ClickhouseQueryView"""


### PR DESCRIPTION
feat: global courses rating API

```
GET api/fx/statistics/v1/rating/?tenant_ids=1,2,3
```

It'll only return the rating for accessible courses. For example, if the user has access to 20 courses out of 20 in the tenant; the result will be the average rating for only the two accessible courses