### PR TITLE
fix: None value returned by Rating API

### DIFF
--- a/futurex_openedx_extensions/__init__.py
+++ b/futurex_openedx_extensions/__init__.py
@@ -1,3 +1,3 @@
 """One-line description for README and other doc files."""
 
-__version__ = '0.6.4'
+__version__ = '0.6.5'

--- a/tests/test_dashboard/test_statistics/test_courses.py
+++ b/tests/test_dashboard/test_statistics/test_courses.py
@@ -61,10 +61,21 @@ def test_get_courses_ratings(base_data, fx_permission_info):  # pylint: disable=
 
     result = courses.get_courses_ratings(fx_permission_info)
     assert result['total_rating'] == 114
-    assert result['total_count'] == 32
     assert result['courses_count'] == 3
     assert result['rating_1_count'] == 3
     assert result['rating_2_count'] == 5
     assert result['rating_3_count'] == 6
     assert result['rating_4_count'] == 7
     assert result['rating_5_count'] == 11
+
+
+@pytest.mark.django_db
+def test_get_courses_ratings_no_rating(base_data, fx_permission_info):  # pylint: disable=unused-argument
+    """Verify that get_courses_ratings returns the correct QuerySet when there are no ratings."""
+    expected_keys = ['total_rating', 'courses_count'] + [
+        f'rating_{i}_count' for i in range(1, 6)
+    ]
+    result = courses.get_courses_ratings(fx_permission_info)
+    assert set(result.keys()) == set(expected_keys)
+    assert all(result[key] is not None for key in expected_keys)
+    assert all(result[key] == 0 for key in expected_keys)

--- a/tests/test_dashboard/test_views.py
+++ b/tests/test_dashboard/test_views.py
@@ -619,6 +619,35 @@ class TestGlobalRatingView(BaseTestViewMixin):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(data, expected_result)
 
+    def test_success_no_rating(self):
+        """Verify that the view returns the correct response when there are no ratings"""
+        self.login_user(self.staff_user)
+        with patch('futurex_openedx_extensions.dashboard.views.get_courses_ratings') as mocked_calc:
+            mocked_calc.return_value = {
+                'total_rating': 0,
+                'courses_count': 0,
+                'rating_1_count': 0,
+                'rating_2_count': 0,
+                'rating_3_count': 0,
+                'rating_4_count': 0,
+                'rating_5_count': 0,
+            }
+            response = self.client.get(self.url)
+        data = json.loads(response.content)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(data, {
+            'total_rating': 0,
+            'total_count': 0,
+            'courses_count': 0,
+            'rating_counts': {
+                '1': 0,
+                '2': 0,
+                '3': 0,
+                '4': 0,
+                '5': 0,
+            },
+        })
+
 
 @ddt.ddt
 class TestClickhouseQueryView(MockPatcherMixin, BaseTestViewMixin):


### PR DESCRIPTION
fix: None value returned by Rating API

Before the fix: the API is crashing on tenants with no rating records