### PR TITLE
fix: CourseAccessRole is always case-insensitive

### DIFF
--- a/futurex_openedx_extensions/__init__.py
+++ b/futurex_openedx_extensions/__init__.py
@@ -1,3 +1,3 @@
 """One-line description for README and other doc files."""
 
-__version__ = '0.7.3'
+__version__ = '0.8.1'

--- a/futurex_openedx_extensions/dashboard/statistics/certificates.py
+++ b/futurex_openedx_extensions/dashboard/statistics/certificates.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from typing import Dict
 
 from django.db.models import Count, OuterRef, Subquery
+from django.db.models.functions import Lower
 from lms.djangoapps.certificates.models import GeneratedCertificate
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 
@@ -36,7 +37,7 @@ def get_certificates_count(
     ).annotate(course_org=Subquery(
         CourseOverview.objects.filter(
             id=OuterRef('course_id')
-        ).values('org')
+        ).values(org_lower_case=Lower('org'))
     )).values('course_org').annotate(certificates_count=Count('id')).values_list('course_org', 'certificates_count'))
 
     return dict(result)

--- a/futurex_openedx_extensions/dashboard/statistics/courses.py
+++ b/futurex_openedx_extensions/dashboard/statistics/courses.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from typing import Dict
 
 from django.db.models import Case, CharField, Count, Q, Sum, Value, When
-from django.db.models.functions import Coalesce
+from django.db.models.functions import Coalesce, Lower
 from django.db.models.query import QuerySet
 from django.utils.timezone import now
 
@@ -32,9 +32,9 @@ def get_courses_count(
         fx_permission_info, visible_filter=visible_filter, active_filter=active_filter
     )
 
-    return q_set.values('org').annotate(
+    return q_set.values(org_lower_case=Lower('org')).annotate(
         courses_count=Count('id')
-    ).order_by('org')
+    ).order_by(Lower('org'))
 
 
 def get_courses_count_by_status(

--- a/futurex_openedx_extensions/helpers/roles.py
+++ b/futurex_openedx_extensions/helpers/roles.py
@@ -143,10 +143,9 @@ def get_all_course_access_roles() -> dict:
         if course_id:
             if course_id not in course_org:
                 course_org[course_id] = org
-            if course_id not in result[user_id][role]['course_limited_access']:
-                result[user_id][role]['course_limited_access'].append(course_id)
+            result[user_id][role]['course_limited_access'].append(course_id)
 
-        elif org not in result[user_id][role]['orgs_full_access']:
+        else:
             result[user_id][role]['orgs_full_access'].append(org)
 
     optimize_access_roles_result(result, course_org)

--- a/futurex_openedx_extensions/helpers/roles.py
+++ b/futurex_openedx_extensions/helpers/roles.py
@@ -49,7 +49,7 @@ def is_valid_course_access_role(course_access_role: dict) -> bool:
         logger.error('Invalid course access role (course_id with no org!): id=%s', course_access_role['id'])
         return False
 
-    if course_id and org != course_access_role['course_org']:
+    if course_id and org.lower() != course_access_role['course_org'].lower():
         logger.error('Invalid course access role (org mismatch!): id=%s', course_access_role['id'])
         return False
 
@@ -128,7 +128,7 @@ def get_all_course_access_roles() -> dict:
 
         user_id = access_role['user_id']
         role = access_role['role']
-        org = access_role['org']
+        org = access_role['org'].lower()
         course_id = str(access_role['course_id']) if access_role['course_id'] else None
 
         if user_id not in result:

--- a/futurex_openedx_extensions/helpers/tenants.py
+++ b/futurex_openedx_extensions/helpers/tenants.py
@@ -154,7 +154,7 @@ def get_all_course_org_filter_list() -> Dict[int, List[str]]:
         course_org_filter = config.get('course_org_filter', [])
         if isinstance(course_org_filter, str):
             course_org_filter = [course_org_filter]
-        result[t_id] = course_org_filter
+        result[t_id] = sorted(list({org.strip().lower() for org in course_org_filter}))
 
     return result
 
@@ -246,7 +246,7 @@ def get_accessible_tenant_ids(user: get_user_model, roles_filter: List[str] | No
     accessible_orgs = accessible_orgs.values_list('org', flat=True).distinct()
 
     return [t_id for t_id, course_org_filter in course_org_filter_list.items() if any(
-        org in course_org_filter for org in accessible_orgs
+        org.lower() in [org_filter.lower() for org_filter in course_org_filter] for org in accessible_orgs
     )]
 
 
@@ -260,7 +260,10 @@ def get_tenants_by_org(org: str) -> List[int]:
     :rtype: List[int]
     """
     tenant_configs = get_all_course_org_filter_list()
-    return [t_id for t_id, course_org_filter in tenant_configs.items() if org in course_org_filter]
+    result = [t_id for t_id, course_org_filter in tenant_configs.items() if org.lower() in [
+        org_filter.lower() for org_filter in course_org_filter
+    ]]
+    return list(set(result))
 
 
 def get_tenants_sites(tenant_ids: List[int]) -> List[str]:

--- a/test_utils/edx_platform_mocks/fake_models/models.py
+++ b/test_utils/edx_platform_mocks/fake_models/models.py
@@ -8,7 +8,7 @@ from opaque_keys.edx.django.models import CourseKeyField, LearningContextKeyFiel
 class CourseOverview(models.Model):
     """Mock"""
     id = models.CharField(max_length=255, primary_key=True)  # pylint: disable=invalid-name
-    org = models.CharField(max_length=255)
+    org = models.CharField(max_length=255, db_collation='NOCASE')
     catalog_visibility = models.TextField(null=True)
     start = models.DateTimeField(null=True)
     end = models.DateTimeField(null=True)
@@ -28,12 +28,13 @@ class CourseAccessRole(models.Model):
     """Mock"""
     user = models.ForeignKey(get_user_model(), on_delete=models.CASCADE)
     role = models.CharField(max_length=255)
-    org = models.CharField(blank=True, max_length=255)
+    org = models.CharField(blank=True, max_length=255, db_collation='NOCASE')
     course_id = CourseKeyField(max_length=255, db_index=True, blank=True)
 
     class Meta:
         app_label = 'fake_models'
         db_table = 'student_courseaccessrole'
+        unique_together = ('user', 'org', 'course_id', 'role')
 
 
 class CourseEnrollment(models.Model):

--- a/tests/base_test_data.py
+++ b/tests/base_test_data.py
@@ -6,7 +6,7 @@ _base_data = {
             'lms_configs': {
                 'LMS_BASE': 's1.sample.com',
                 'SITE_NAME': 's1.sample.com',
-                'course_org_filter': ['ORG1', 'ORG2'],
+                'course_org_filter': ['ORG1', 'ORG2', 'Org1'],
                 'IS_FX_DASHBOARD_ENABLED': True,
             },
         },
@@ -106,16 +106,21 @@ _base_data = {
         'dah.sample.com': [1, 2, 3, 4, 5],  # This is not a valid domain
     },
     'course_overviews': {  # count of courses per org
-        'ORG1': 5,
-        'ORG2': 7,
-        'ORG3': 3,
-        'ORG4': 1,
-        'ORG5': 0,
-        'ORG6': 1,  # This is an org with no tenant
-        'ORG8': 2,
+        'Org1': (1, 1),
+        'ORG1': (2, 5),
+        'ORG2': (1, 7),
+        'ORG3': (1, 3),
+        'ORG4': (1, 1),
+        'ORG5': None,
+        'ORG6': (1, 1),  # This is an org with no tenant
+        'ORG8': (1, 2),
+        'incompatible_org_case': {
+            'course-v1:Org1+1+1': 'oRg1',
+            'course-v1:ORG1+3+3': 'org1',
+        },
     },
     'course_attributes': {  # org id, course id
-        'course-v1:ORG1+1+1': {
+        'course-v1:Org1+1+1': {
             'start': 'F',
         },
         'course-v1:ORG1+2+2': {
@@ -150,8 +155,10 @@ _base_data = {
         },
     },
     'course_enrollments': {  # org id, course id, user ids
-        'ORG1': {
+        'Org1': {
             1: [4, 5],
+        },
+        'ORG1': {
             2: [3],
             3: [],
             4: [4],
@@ -186,11 +193,11 @@ _base_data = {
     'inactive_users': [61, 62, 63],
     'course_access_roles_org_wide': {  # roles, user ids per org
         'staff': {
-            'ORG1': [3],
-            'ORG2': [8],
-            'ORG3': [9, 18],
-            'ORG4': [10, 23],
-            'ORG5': [23],
+            'Org1': [3],
+            'Org2': [8],
+            'Org3': [9, 18],
+            'Org4': [10, 23],
+            'Org5': [23],
         },
         'org_course_creator_group': {
             'ORG1': [4],
@@ -205,48 +212,48 @@ _base_data = {
         }
     },
     'course_access_roles_course_specific': {  # org id, course id, roles, user ids
-        'ORG1': {
-            1: {
+        'Org1': {
+            'course-v1:Org1+1+1': {
                 'staff': [1],
                 'org_course_creator_group': [1],
             },
-            2: {
+            'course-v1:ORG1+2+2': {
                 'staff': [1],
                 'org_course_creator_group': [2],
             },
-            3: {
+            'course-v1:ORG1+3+3': {
                 'staff': [3],
                 'org_course_creator_group': [3],
             },
-            4: {
+            'course-v1:ORG1+4+4': {
                 'staff': [4],
                 'org_course_creator_group': [3],
             },
         },
-        'ORG2': {
-            1: {
+        'Org2': {
+            'course-v1:ORG2+1+1': {
                 'staff': [9],
                 'org_course_creator_group': [1],
             },
-            2: {
+            'course-v1:ORG2+2+2': {
                 'staff': [1],
                 'org_course_creator_group': [2],
             },
-            3: {
+            'course-v1:ORG2+3+3': {
                 'staff': [9],
                 'org_course_creator_group': [8],
             },
         },
-        'ORG3': {
-            1: {
+        'Org3': {
+            'course-v1:ORG3+1+1': {
                 'staff': [4],
                 'org_course_creator_group': [4],
             },
-            2: {
+            'course-v1:ORG3+2+2': {
                 'data_researcher': [9],
                 'org_course_creator_group': [11],
             },
-            3: {
+            'course-v1:ORG3+3+3': {
                 'staff': [18],
                 'org_course_creator_group': [9],
             },

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,8 +28,11 @@ def user1_fx_permission_info():
 
 
 @pytest.fixture(scope='session')
-def base_data(django_db_setup, django_db_blocker):  # pylint: disable=unused-argument
+def base_data(django_db_setup, django_db_blocker):  # pylint: disable=unused-argument, too-many-statements
     """Create base data for tests."""
+    def _get_course_id(org, course_index):
+        return f'course-v1:{org}+{course_index}+{course_index}'
+
     def _create_users():
         """Create users."""
         user = get_user_model()
@@ -83,10 +86,11 @@ def base_data(django_db_setup, django_db_blocker):  # pylint: disable=unused-arg
                         org=org,
                     )
         for org, courses in _base_data['course_access_roles_course_specific'].items():
-            for course_index, roles in courses.items():
+            for course_id, roles in courses.items():
                 for role, users in roles.items():
                     for user_id in users:
-                        course_id = f'course-v1:{org}+{course_index}+{course_index}'
+                        assert CourseOverview.objects.filter(id=course_id).exists(), \
+                            f'Bad course_id in access roles testing data for org: {org}, course: {course_id}'
                         CourseAccessRole.objects.create(
                             user_id=user_id,
                             role=role,
@@ -107,17 +111,23 @@ def base_data(django_db_setup, django_db_blocker):  # pylint: disable=unused-arg
                     }
                     CourseAccessRole.objects.create(**params)
 
-    def _create_course_overviews():
+    def _create_course_overviews():  # pylint: disable=too-many-branches
         """Create course overviews."""
-        for org, count in _base_data['course_overviews'].items():
-            for i in range(1, count + 1):
+        incompatible_org_case = _base_data['course_overviews'].pop('incompatible_org_case')
+        for org, index_range in _base_data['course_overviews'].items():
+            if index_range is None:
+                continue
+            for i in range(index_range[0], index_range[1] + 1):
+                course_id = _get_course_id(org, i)
                 CourseOverview.objects.create(
-                    id=f'course-v1:{org}+{i}+{i}',
-                    org=org,
+                    id=course_id,
+                    org=org if course_id not in incompatible_org_case else incompatible_org_case[course_id],
                     catalog_visibility='both',
                     display_name=f'Course {i} of {org}',
                 )
-
+        for course_id in incompatible_org_case:
+            assert CourseOverview.objects.filter(id=course_id).exists(), \
+                f'Bad course_id in course_overviews testing data for incompatible_org_case: {course_id}'
         now_time = timezone.now()
         for course_id, data in _base_data['course_attributes'].items():
             course = CourseOverview.objects.get(id=course_id)
@@ -142,15 +152,16 @@ def base_data(django_db_setup, django_db_blocker):  # pylint: disable=unused-arg
     def _create_course_enrollments():
         """Create course enrollments."""
         for org, enrollments in _base_data['course_enrollments'].items():
-            for course_id, users in enrollments.items():
+            for course_index, users in enrollments.items():
                 for user_id in users:
-                    assert 0 < course_id <= _base_data['course_overviews'][org], \
+                    course_id = _get_course_id(org, course_index)
+                    assert CourseOverview.objects.filter(id=course_id).exists(), \
                         f'Bad course_id in enrollment testing data for org: {org}, course: {course_id}'
                     assert 0 < user_id <= _base_data['users_count'], \
                         f'Bad user_id in enrollment testing data for org: {org}, user: {user_id}, course: {course_id}'
                     CourseEnrollment.objects.create(
                         user_id=user_id,
-                        course_id=f'course-v1:{org}+{course_id}+{course_id}',
+                        course_id=course_id,
                         is_active=True,
                     )
 
@@ -161,7 +172,7 @@ def base_data(django_db_setup, django_db_blocker):  # pylint: disable=unused-arg
                 for user_id in user_ids:
                     GeneratedCertificate.objects.create(
                         user_id=user_id,
-                        course_id=f'course-v1:{org}+{course_id}+{course_id}',
+                        course_id=_get_course_id(org, course_id),
                         status='downloadable',
                     )
 
@@ -170,8 +181,8 @@ def base_data(django_db_setup, django_db_blocker):  # pylint: disable=unused-arg
         _create_tenants()
         _create_routes()
         _create_user_signup_sources()
+        _create_course_overviews()
         _create_course_access_roles()
         _create_ignored_course_access_roles()
-        _create_course_overviews()
         _create_course_enrollments()
         _create_certificates()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,7 +16,7 @@ def fx_permission_info():
     """Fixture for permission information."""
     return {
         'is_system_staff_user': True,
-        'view_allowed_full_access_orgs': ['ORG1', 'ORG2'],
+        'view_allowed_full_access_orgs': ['org1', 'org2'],
         'view_allowed_course_access_orgs': [],
     }
 

--- a/tests/fixture_helpers.py
+++ b/tests/fixture_helpers.py
@@ -20,20 +20,20 @@ def get_user1_fx_permission_info():
 
 def get_all_orgs():
     """Get all test valid organizations."""
-    return ['ORG1', 'ORG2', 'ORG3', 'ORG8', 'ORG4', 'ORG5']
+    return ['org1', 'org2', 'org3', 'org8', 'org4', 'org5']
 
 
 def get_tenants_orgs(tenant_id):
     """Get test valid organizations for a tenants."""
     orgs = {
-        1: ['ORG1', 'ORG2'],
-        2: ['ORG3', 'ORG8'],
-        3: ['ORG4', 'ORG5'],
+        1: ['org1', 'org2'],
+        2: ['org3', 'org8'],
+        3: ['org4', 'org5'],
         4: [],
         5: [],
         6: [],
-        7: ['ORG3'],
-        8: ['ORG8'],
+        7: ['org3'],
+        8: ['org8'],
     }
     result = set()
     for tenant in tenant_id:
@@ -55,47 +55,47 @@ def get_test_data_dict():
     """Get the test data dictionary."""
     return {
         'user3': {
-            'ORG1': {
+            'org1': {
                 'None': ['staff'],
                 'course-v1:ORG1+3+3': ['staff', 'org_course_creator_group'],
                 'course-v1:ORG1+4+4': ['org_course_creator_group'],
             }
         },
         'user8': {
-            'ORG2': {'None': ['staff'], 'course-v1:ORG2+3+3': ['org_course_creator_group']}
+            'org2': {'None': ['staff'], 'course-v1:ORG2+3+3': ['org_course_creator_group']}
         },
         'user9': {
-            'ORG3': {
+            'org3': {
                 'None': ['staff', 'data_researcher'],
                 'course-v1:ORG3+2+2': ['data_researcher'],
                 'course-v1:ORG3+3+3': ['org_course_creator_group'],
             },
-            'ORG2': {'course-v1:ORG2+1+1': ['staff'], 'course-v1:ORG2+3+3': ['staff']},
+            'org2': {'course-v1:ORG2+1+1': ['staff'], 'course-v1:ORG2+3+3': ['staff']},
         },
-        'user18': {'ORG3': {'None': ['staff'], 'course-v1:ORG3+3+3': ['staff']}},
+        'user18': {'org3': {'None': ['staff'], 'course-v1:ORG3+3+3': ['staff']}},
         'user10': {
-            'ORG4': {'None': ['staff']},
-            'ORG3': {'None': ['data_researcher']},
+            'org4': {'None': ['staff']},
+            'org3': {'None': ['data_researcher']},
         },
         'user23': {
-            'ORG4': {'None': ['staff', 'org_course_creator_group']},
-            'ORG5': {'None': ['staff', 'org_course_creator_group']},
-            'ORG8': {'None': ['org_course_creator_group']},
+            'org4': {'None': ['staff', 'org_course_creator_group']},
+            'org5': {'None': ['staff', 'org_course_creator_group']},
+            'org8': {'None': ['org_course_creator_group']},
         },
         'user4': {
-            'ORG1': {'None': ['org_course_creator_group'], 'course-v1:ORG1+4+4': ['staff']},
-            'ORG2': {'None': ['org_course_creator_group']},
-            'ORG3': {
+            'org1': {'None': ['org_course_creator_group'], 'course-v1:ORG1+4+4': ['staff']},
+            'org2': {'None': ['org_course_creator_group']},
+            'org3': {
                 'None': ['org_course_creator_group'],
                 'course-v1:ORG3+1+1': ['staff', 'org_course_creator_group'],
             },
         },
         'user11': {
-            'ORG3': {
+            'org3': {
                 'course-v1:ORG3+2+2': ['org_course_creator_group'],
             }
         },
-        'user48': {'ORG4': {'None': ['org_course_creator_group']}},
+        'user48': {'org4': {'None': ['org_course_creator_group']}},
     }
 
 
@@ -103,36 +103,36 @@ def get_test_data_dict_without_course_roles():
     """Get the test data dictionary without course roles."""
     return {
         'user3': {
-            'ORG1': {
+            'org1': {
                 'None': ['staff'],
             }
         },
         'user8': {
-            'ORG2': {'None': ['staff']}
+            'org2': {'None': ['staff']}
         },
         'user9': {
-            'ORG3': {
+            'org3': {
                 'None': ['staff', 'data_researcher'],
             },
         },
-        'user18': {'ORG3': {'None': ['staff']}},
+        'user18': {'org3': {'None': ['staff']}},
         'user10': {
-            'ORG4': {'None': ['staff']},
-            'ORG3': {'None': ['data_researcher']},
+            'org4': {'None': ['staff']},
+            'org3': {'None': ['data_researcher']},
         },
         'user23': {
-            'ORG4': {'None': ['staff', 'org_course_creator_group']},
-            'ORG5': {'None': ['staff', 'org_course_creator_group']},
-            'ORG8': {'None': ['org_course_creator_group']},
+            'org4': {'None': ['staff', 'org_course_creator_group']},
+            'org5': {'None': ['staff', 'org_course_creator_group']},
+            'org8': {'None': ['org_course_creator_group']},
         },
         'user4': {
-            'ORG1': {'None': ['org_course_creator_group']},
-            'ORG2': {'None': ['org_course_creator_group']},
-            'ORG3': {
+            'org1': {'None': ['org_course_creator_group']},
+            'org2': {'None': ['org_course_creator_group']},
+            'org3': {
                 'None': ['org_course_creator_group'],
             },
         },
-        'user48': {'ORG4': {'None': ['org_course_creator_group']}}
+        'user48': {'org4': {'None': ['org_course_creator_group']}}
     }
 
 
@@ -140,19 +140,19 @@ def get_test_data_dict_without_course_roles_org3():
     """Get the test data dictionary without course roles filtered on org3 and 8."""
     return {
         'user9': {
-            'ORG3': {
+            'org3': {
                 'None': ['staff', 'data_researcher'],
             },
         },
-        'user18': {'ORG3': {'None': ['staff']}},
+        'user18': {'org3': {'None': ['staff']}},
         'user10': {
-            'ORG3': {'None': ['data_researcher']},
+            'org3': {'None': ['data_researcher']},
         },
         'user23': {
-            'ORG8': {'None': ['org_course_creator_group']},
+            'org8': {'None': ['org_course_creator_group']},
         },
         'user4': {
-            'ORG3': {
+            'org3': {
                 'None': ['org_course_creator_group'],
             },
         },

--- a/tests/test_dashboard/test_details/test_details_courses.py
+++ b/tests/test_dashboard/test_details/test_details_courses.py
@@ -17,13 +17,13 @@ from futurex_openedx_extensions.dashboard.details.courses import (
 
 @pytest.mark.django_db
 @pytest.mark.parametrize('orgs, search_text, expected_count', [
-    (['ORG3', 'ORG8'], None, 5),
-    (['ORG3'], None, 3),
-    (['ORG8'], None, 2),
-    (['ORG3'], 'Course 1', 1),
-    (['ORG3'], 'Course 3', 1),
-    (['ORG3'], 'course 3', 1),
-    (['ORG3'], 'course 4', 0),
+    (['org3', 'org8'], None, 5),
+    (['org3'], None, 3),
+    (['org8'], None, 2),
+    (['org3'], 'Course 1', 1),
+    (['org3'], 'Course 3', 1),
+    (['org3'], 'course 3', 1),
+    (['org3'], 'course 4', 0),
     (['ORGX'], None, 0),
     ([], None, 0),
 ])
@@ -39,7 +39,7 @@ def test_get_courses_queryset(
 def test_get_courses_queryset_result_excludes_staff(base_data, fx_permission_info):  # pylint: disable=unused-argument
     """Verify that get_courses_queryset excludes staff users from enrollment, but not from certificates."""
     expected_results = {
-        'course-v1:ORG1+1+1': [1, 0],
+        'course-v1:Org1+1+1': [1, 0],
         'course-v1:ORG1+2+2': [0, 0],
         'course-v1:ORG1+3+3': [0, 0],
         'course-v1:ORG1+4+4': [0, 0],
@@ -96,7 +96,7 @@ def test_annotate_courses_rating_queryset(base_data, fx_permission_info):  # pyl
             course_id=course,
             rating_content=rating,
         )
-    queryset = annotate_courses_rating_queryset(CourseOverview.objects.filter(org__in=['ORG1', 'ORG2']))
+    queryset = annotate_courses_rating_queryset(CourseOverview.objects.filter(org__in=['org1', 'org2']))
     for record in queryset:
         if record.id != course.id:
             continue

--- a/tests/test_dashboard/test_serializers.py
+++ b/tests/test_dashboard/test_serializers.py
@@ -42,8 +42,8 @@ def serializer_context():
     return {
         'request': Mock(
             fx_permission_info={
-                'view_allowed_full_access_orgs': ['ORG1', 'ORG2'],
-                'view_allowed_course_access_orgs': ['ORG3'],
+                'view_allowed_full_access_orgs': ['org1', 'org2'],
+                'view_allowed_course_access_orgs': ['org3'],
                 'permitted_tenant_ids': [1, 3],
             },
             query_params={},
@@ -369,7 +369,7 @@ def test_user_roles_serializer_init(
 
     assert mock_construct_roles_data.called
     assert mock_construct_roles_data.call_args[0][0] == [user3]
-    assert serializer.orgs_filter == ['ORG1', 'ORG2', 'ORG3']
+    assert serializer.orgs_filter == ['org1', 'org2', 'org3']
     assert serializer.permitted_tenant_ids == \
            serializer_context['request'].fx_permission_info['permitted_tenant_ids']
     assert serializer.data == {
@@ -424,12 +424,12 @@ def test_user_roles_serializer_get_org_tenants(
         mock_get_tenants_by_org.return_value = [1, 2]
         assert isinstance(serializer._org_tenant, dict)  # pylint: disable=protected-access
         assert not serializer._org_tenant  # pylint: disable=protected-access
-        assert serializer.get_org_tenants('ORG1') == [1, 2]
-        assert serializer._org_tenant == {'ORG1': [1, 2]}  # pylint: disable=protected-access
+        assert serializer.get_org_tenants('org1') == [1, 2]
+        assert serializer._org_tenant == {'org1': [1, 2]}  # pylint: disable=protected-access
         mock_get_tenants_by_org.assert_called_once()
 
         mock_get_tenants_by_org.reset_mock()
-        assert serializer.get_org_tenants('ORG1') == [1, 2]
+        assert serializer.get_org_tenants('org1') == [1, 2]
         mock_get_tenants_by_org.assert_not_called()
 
 

--- a/tests/test_dashboard/test_statistics/test_certificates.py
+++ b/tests/test_dashboard/test_statistics/test_certificates.py
@@ -8,17 +8,17 @@ from tests.fixture_helpers import get_tenants_orgs
 
 @pytest.mark.django_db
 @pytest.mark.parametrize('tenant_ids, expected_result', [
-    ([1], {'ORG1': 4, 'ORG2': 10}),
-    ([2], {'ORG3': 7, 'ORG8': 2}),
+    ([1], {'org1': 4, 'org2': 10}),
+    ([2], {'org3': 7, 'org8': 2}),
     ([3], {}),
     ([4], {}),
     ([5], {}),
     ([6], {}),
-    ([7], {'ORG3': 7}),
-    ([8], {'ORG8': 2}),
-    ([1, 2], {'ORG1': 4, 'ORG2': 10, 'ORG3': 7, 'ORG8': 2}),
-    ([2, 7], {'ORG3': 7, 'ORG8': 2}),
-    ([7, 8], {'ORG3': 7, 'ORG8': 2}),
+    ([7], {'org3': 7}),
+    ([8], {'org8': 2}),
+    ([1, 2], {'org1': 4, 'org2': 10, 'org3': 7, 'org8': 2}),
+    ([2, 7], {'org3': 7, 'org8': 2}),
+    ([7, 8], {'org3': 7, 'org8': 2}),
 ])
 def test_get_certificates_count(
     base_data, fx_permission_info, tenant_ids, expected_result
@@ -34,7 +34,7 @@ def test_get_certificates_count(
 def test_get_certificates_count_not_downloadable(base_data, fx_permission_info):  # pylint: disable=unused-argument
     """Verify get_certificates_count function with empty tenant_ids."""
     result = certificates.get_certificates_count(fx_permission_info)
-    assert result == {'ORG1': 4, 'ORG2': 10}, f'Wrong certificates result. expected: {result}'
+    assert result == {'org1': 4, 'org2': 10}, f'Wrong certificates result. expected: {result}'
 
     some_status_not_downloadable = 'whatever'
     GeneratedCertificate.objects.filter(
@@ -42,4 +42,4 @@ def test_get_certificates_count_not_downloadable(base_data, fx_permission_info):
         user_id=40,
     ).update(status=some_status_not_downloadable)
     result = certificates.get_certificates_count(fx_permission_info)
-    assert result == {'ORG1': 3, 'ORG2': 10}, f'Wrong certificates result. expected: {result}'
+    assert result == {'org1': 3, 'org2': 10}, f'Wrong certificates result. expected: {result}'

--- a/tests/test_dashboard/test_statistics/test_courses.py
+++ b/tests/test_dashboard/test_statistics/test_courses.py
@@ -17,15 +17,18 @@ def test_get_courses_count(base_data, fx_permission_info):  # pylint: disable=un
         list(all_tenants)
     )['course_org_filter_list']
     result = courses.get_courses_count(fx_permission_info)
-    orgs_in_result = [org['org'] for org in result]
+    orgs_in_result = [org['org_lower_case'] for org in result]
 
     for tenant_id in all_tenants:
         course_org_filter_list = get_course_org_filter_list([tenant_id])['course_org_filter_list']
         for org in course_org_filter_list:
-            expected_count = _base_data['course_overviews'].get(org, 0)
+            expected_count = 0
+            for data_org, course_index_range in _base_data['course_overviews'].items():
+                if org == data_org.lower() and course_index_range is not None:
+                    expected_count += course_index_range[1] - course_index_range[0] + 1
             assert (
                 expected_count != 0 and {
-                    'org': org, 'courses_count': _base_data['course_overviews'].get(org, 0)
+                    'org_lower_case': org, 'courses_count': expected_count
                 } in result or
                 expected_count == 0 and org not in orgs_in_result
             ), f'Missing org: {org} in tenant: {tenant_id} results'

--- a/tests/test_dashboard/test_views.py
+++ b/tests/test_dashboard/test_views.py
@@ -16,7 +16,7 @@ from rest_framework.test import APIRequestFactory, APITestCase
 
 from futurex_openedx_extensions.dashboard import serializers, urls, views
 from futurex_openedx_extensions.helpers import clickhouse_operations as ch
-from futurex_openedx_extensions.helpers.constants import CLICKHOUSE_FX_BUILTIN_CA_USERS_OF_TENANTS, COURSE_STATUSES
+from futurex_openedx_extensions.helpers.constants import CLICKHOUSE_FX_BUILTIN_CA_USERS_OF_TENANTS
 from futurex_openedx_extensions.helpers.filters import DefaultOrderingFilter
 from futurex_openedx_extensions.helpers.models import ViewAllowedRoles
 from futurex_openedx_extensions.helpers.pagination import DefaultPagination
@@ -170,37 +170,13 @@ class TestCoursesView(BaseTestViewMixin):
             assert mock_queryset.call_args_list[0][1]['search_text'] == 'course'
             assert mock_queryset.call_args_list[0][1]['visible_filter'] is None
 
-    def helper_test_success(self, response):
-        """Verify that the view returns the correct response"""
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.data['count'], 18)
-        self.assertGreater(len(response.data['results']), 0)
-        self.assertEqual(response.data['results'][0]['id'], 'course-v1:ORG1+1+1')
-
     def test_success(self):
         """Verify that the view returns the correct response"""
         self.login_user(self.staff_user)
         response = self.client.get(self.url)
-        self.helper_test_success(response=response)
-        self.assertEqual(response.data['results'][0]['status'], COURSE_STATUSES['upcoming'])
-
-    def test_status_archived(self):
-        """Verify that the view sets the correct status when the course is archived"""
-        CourseOverview.objects.filter(id='course-v1:ORG1+1+1').update(end=now() - timedelta(days=1))
-
-        self.login_user(self.staff_user)
-        response = self.client.get(self.url)
-        self.helper_test_success(response=response)
-        self.assertEqual(response.data['results'][0]['status'], 'archived')
-
-    def test_status_upcoming(self):
-        """Verify that the view sets the correct status when the course is upcoming"""
-        CourseOverview.objects.filter(id='course-v1:ORG1+1+1').update(start=now() + timedelta(days=1))
-
-        self.login_user(self.staff_user)
-        response = self.client.get(self.url)
-        self.helper_test_success(response=response)
-        self.assertEqual(response.data['results'][0]['status'], 'upcoming')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data['count'], 18)
+        self.assertEqual(len(response.data['results']), 18)
 
     def test_sorting(self):
         """Verify that the view soring filter is set correctly"""
@@ -810,7 +786,7 @@ class TestClickhouseQueryView(MockPatcherMixin, BaseTestViewMixin):
     def test_success_ca_users_needed(self):
         """Verify that the view gets the CA users when the query needs them"""
         self.url_args = ['course', 'test-query-ca-users-nop']
-        all_orgs = ['ORG1', 'ORG2', 'ORG3', 'ORG8', 'ORG4', 'ORG5']
+        all_orgs = ['org1', 'org2', 'org3', 'org8', 'org4', 'org5']
 
         self.login_user(self.staff_user)
         response = self.client.get(self.url)

--- a/tests/test_helpers/test_extractors.py
+++ b/tests/test_helpers/test_extractors.py
@@ -21,9 +21,9 @@ def test_get_first_not_empty_item(items, expected, error_message):
 
 
 @pytest.mark.parametrize('uri, expected_course_id', [
-    ('http://domain/path/course-v1:ORG1+1+1/?page=1&page_size=%2F', 'course-v1:ORG1+1+1'),
+    ('http://domain/path/course-v1:Org1+1+1/?page=1&page_size=%2F', 'course-v1:Org1+1+1'),
     ('http://domain/path/course-v1:ORG2+2+2/?page=2&page_size=10', 'course-v1:ORG2+2+2'),
-    ('http://domain/path/course-v1:ORG1+1+1', 'course-v1:ORG1+1+1'),
+    ('http://domain/path/course-v1:Org1+1+1', 'course-v1:Org1+1+1'),
     ('http://domain/path/course-v1:ORG3+3+3/', 'course-v1:ORG3+3+3'),
     ('http://domain/path', None),
     ('http://domain/path?course_id=course-v1:ORG2+2+2', None),

--- a/tests/test_helpers/test_permissions.py
+++ b/tests/test_helpers/test_permissions.py
@@ -165,8 +165,8 @@ def test_fx_base_authenticated_permission_selected_tenants(
 ):  # pylint: disable=unused-argument, redefined-outer-name
     """Verify that FXBaseAuthenticatedPermission recognizes selected tenants."""
     user_id = 9
-    tenant_1_and_2_orgs = ['ORG1', 'ORG2', 'ORG3', 'ORG8']
-    tenant_3_orgs = ['ORG4', 'ORG5']
+    tenant_1_and_2_orgs = ['org1', 'org2', 'org3', 'org8']
+    tenant_3_orgs = ['org4', 'org5']
     assert CourseAccessRole.objects.filter(user_id=user_id, org__in=tenant_1_and_2_orgs).exists(), \
         f'Bad test data, user{user_id} should have access to Tenant 1 and 2'
     assert not CourseAccessRole.objects.filter(user_id=user_id, org__in=tenant_3_orgs).exists(), \
@@ -267,15 +267,15 @@ def test_get_tenant_limited_fx_permission_info():
         'permitted_tenant_ids': 'list of tenants, replace with the given tenant_id',
         'view_allowed_roles': 'list of roles, copy as it is',
         'view_allowed_full_access_orgs': [
-            'intersection of this list and the list of orgs for the given tenant', 'ORG1', 'ORG3'
+            'intersection of this list and the list of orgs for the given tenant', 'org1', 'org3'
         ],
         'view_allowed_course_access_orgs': [
-            'intersection of this list and the list of orgs for the given tenant', 'ORG2', 'ORG3', 'ORG4'
+            'intersection of this list and the list of orgs for the given tenant', 'org2', 'org3', 'org4'
         ],
     }
 
     with patch('futurex_openedx_extensions.helpers.permissions.get_course_org_filter_list', return_value={
-        'course_org_filter_list': ['ORG1', 'ORG2']
+        'course_org_filter_list': ['org1', 'org2']
     }):
         assert get_tenant_limited_fx_permission_info(fx_permission_info, 1) == {
             'user': fx_permission_info['user'],
@@ -283,6 +283,6 @@ def test_get_tenant_limited_fx_permission_info():
             'is_system_staff_user': fx_permission_info['is_system_staff_user'],
             'permitted_tenant_ids': [1],
             'view_allowed_roles': fx_permission_info['view_allowed_roles'],
-            'view_allowed_full_access_orgs': ['ORG1'],
-            'view_allowed_course_access_orgs': ['ORG2'],
+            'view_allowed_full_access_orgs': ['org1'],
+            'view_allowed_course_access_orgs': ['org2'],
         }

--- a/tests/test_helpers/test_querysets.py
+++ b/tests/test_helpers/test_querysets.py
@@ -33,7 +33,7 @@ def test_get_base_queryset_courses_non_staff(base_data, fx_permission_info):  # 
 @pytest.mark.django_db
 def test_get_base_queryset_courses_visible_filter(base_data, fx_permission_info):  # pylint: disable=unused-argument
     """Verify get_base_queryset_courses function with visible_filter."""
-    course = CourseOverview.objects.filter(org='ORG1').first()
+    course = CourseOverview.objects.filter(org='org1').first()
     assert course.catalog_visibility == 'both', 'Catalog visibility should be initialized as (both) for test courses'
     course.catalog_visibility = 'none'
     course.save()
@@ -66,15 +66,15 @@ def test_get_base_queryset_courses_limited_course_roles(
         'user': get_user_model().objects.get(username='user4'),
         'is_system_staff_user': False,
         'view_allowed_full_access_orgs': [],
-        'view_allowed_course_access_orgs': ['ORG2'],
+        'view_allowed_course_access_orgs': ['org2'],
         'view_allowed_roles': ['org_course_creator_group'],
     })
-    course_role = CourseAccessRole.objects.get(user_id=4, org='ORG2')
+    course_role = CourseAccessRole.objects.get(user_id=4, org='org2')
     course_role.course_id = 'course-v1:ORG2+2+2'
     course_role.save()
     result = querysets.get_base_queryset_courses(fx_permission_info)
     assert result.count() == 1
-    assert result.first().org == 'ORG2'
+    assert result.first().org.lower() == 'org2'
 
 
 @pytest.mark.django_db

--- a/tests/test_helpers/test_roles.py
+++ b/tests/test_helpers/test_roles.py
@@ -195,21 +195,9 @@ def test_get_all_course_access_roles(base_data):  # pylint: disable=unused-argum
     CourseAccessRole.objects.create(
         user_id=3,
         role='staff',
-        org='ORG1',
-    )
-    CourseAccessRole.objects.create(
-        user_id=3,
-        role='staff',
         org='ORG2',
         course_id='course-v1:ORG2+2+2',
     )
-    for _ in range(2):
-        CourseAccessRole.objects.create(
-            user_id=4,
-            role='staff',
-            org='ORG2',
-            course_id='course-v1:ORG2+2+2',
-        )
 
     expected_result['staff']['orgs_of_courses'] = ['ORG2']
     expected_result['staff']['course_limited_access'] = ['course-v1:ORG2+2+2']

--- a/tests/test_helpers/test_roles.py
+++ b/tests/test_helpers/test_roles.py
@@ -52,14 +52,14 @@ def reset_fx_views_with_roles():
     ({
         'id': 99,
         'org': '',
-        'course_id': 'course-v1:ORG1+1+1',
-        'course_org': 'ORG1',
+        'course_id': 'course-v1:Org1+1+1',
+        'course_org': 'org1',
     }, ('Invalid course access role (course_id with no org!): id=%s', 99)),
     ({
         'id': 99,
-        'org': 'ORG2',
-        'course_id': 'course-v1:ORG1+1+1',
-        'course_org': 'ORG1',
+        'org': 'org2',
+        'course_id': 'course-v1:Org1+1+1',
+        'course_org': 'org1',
     }, ('Invalid course access role (org mismatch!): id=%s', 99)),
 ])
 def test_is_valid_course_access_role_invalid(course_access_role, error_msg):
@@ -75,53 +75,53 @@ def test_optimize_access_roles_result():
     access_roles = {
         1: {
             'whatever1': {
-                'orgs_full_access': ['ORG1'], 'course_limited_access': ['course-v1:ORG1+1+1', 'course2']
+                'orgs_full_access': ['org1'], 'course_limited_access': ['course-v1:Org1+1+1', 'course2']
             },
             'whatever2': {
-                'orgs_full_access': ['ORG3'], 'course_limited_access': ['course-v1:ORG1+1+1']
+                'orgs_full_access': ['org3'], 'course_limited_access': ['course-v1:Org1+1+1']
             },
             'whatever3': {
-                'orgs_full_access': ['ORG1'], 'course_limited_access': ['course2', 'course-v1:ORG2+2+2']
+                'orgs_full_access': ['org1'], 'course_limited_access': ['course2', 'course-v1:ORG2+2+2']
             },
         },
         2: {
             'staff': {
-                'orgs_full_access': [], 'course_limited_access': ['course-v1:ORG1+1+1']},
+                'orgs_full_access': [], 'course_limited_access': ['course-v1:Org1+1+1']},
             'admin': {
-                'orgs_full_access': ['ORG2'], 'course_limited_access': ['course-v1:ORG1+1+1', 'course2']
+                'orgs_full_access': ['org2'], 'course_limited_access': ['course-v1:Org1+1+1', 'course2']
             },
         },
     }
     course_org = {
-        'course-v1:ORG1+1+1': 'ORG1',
-        'course-v1:ORG2+2+2': 'ORG2',
-        'course2': 'ORG2',
+        'course-v1:Org1+1+1': 'org1',
+        'course-v1:ORG2+2+2': 'org2',
+        'course2': 'org2',
     }
     optimize_access_roles_result(access_roles, course_org)
     assert access_roles == {
         1: {
             'whatever1': {
-                'orgs_full_access': ['ORG1'], 'course_limited_access': ['course2'], 'orgs_of_courses': ['ORG2']
+                'orgs_full_access': ['org1'], 'course_limited_access': ['course2'], 'orgs_of_courses': ['org2']
             },
             'whatever2': {
-                'orgs_full_access': ['ORG3'],
-                'course_limited_access': ['course-v1:ORG1+1+1'],
-                'orgs_of_courses': ['ORG1'],
+                'orgs_full_access': ['org3'],
+                'course_limited_access': ['course-v1:Org1+1+1'],
+                'orgs_of_courses': ['org1'],
             },
             'whatever3': {
-                'orgs_full_access': ['ORG1'],
+                'orgs_full_access': ['org1'],
                 'course_limited_access': ['course2', 'course-v1:ORG2+2+2'],
-                'orgs_of_courses': ['ORG2'],
+                'orgs_of_courses': ['org2'],
             },
         },
         2: {
             'staff': {
-                'orgs_full_access': [], 'course_limited_access': ['course-v1:ORG1+1+1'], 'orgs_of_courses': ['ORG1']
+                'orgs_full_access': [], 'course_limited_access': ['course-v1:Org1+1+1'], 'orgs_of_courses': ['org1']
             },
             'admin': {
-                'orgs_full_access': ['ORG2'],
-                'course_limited_access': ['course-v1:ORG1+1+1'],
-                'orgs_of_courses': ['ORG1'],
+                'orgs_full_access': ['org2'],
+                'course_limited_access': ['course-v1:Org1+1+1'],
+                'orgs_of_courses': ['org1'],
             },
         },
     }
@@ -147,14 +147,14 @@ def test_get_all_course_access_roles_ignores_inactive_and_system_admins(
     ).first()
     expected_result = {
         'staff': {
-            'orgs_full_access': ['ORG1'],
+            'orgs_full_access': ['org1'],
             'course_limited_access': [],
             'orgs_of_courses': []
         },
         'org_course_creator_group': {
             'orgs_full_access': [],
             'course_limited_access': ['course-v1:ORG1+3+3', 'course-v1:ORG1+4+4'],
-            'orgs_of_courses': ['ORG1']
+            'orgs_of_courses': ['org1']
         }
     }
     assert user is not None, 'Bad test data, user 3 should be an active non-staff user'
@@ -175,31 +175,31 @@ def test_get_all_course_access_roles(base_data):  # pylint: disable=unused-argum
     _remove_course_access_roles_causing_error_logs()
     expected_result = {
         'staff': {
-            'orgs_full_access': ['ORG1'],
+            'orgs_full_access': ['org1'],
             'course_limited_access': [],
             'orgs_of_courses': []
         },
         'org_course_creator_group': {
             'orgs_full_access': [],
             'course_limited_access': ['course-v1:ORG1+3+3', 'course-v1:ORG1+4+4'],
-            'orgs_of_courses': ['ORG1']
+            'orgs_of_courses': ['org1']
         }
     }
     assert get_all_course_access_roles()[3] == expected_result
     CourseAccessRole.objects.create(
         user_id=3,
         role='staff',
-        org='ORG1',
+        org='org1',
         course_id='course-v1:ORG2+1+1',
     )
     CourseAccessRole.objects.create(
         user_id=3,
         role='staff',
-        org='ORG2',
+        org='org2',
         course_id='course-v1:ORG2+2+2',
     )
 
-    expected_result['staff']['orgs_of_courses'] = ['ORG2']
+    expected_result['staff']['orgs_of_courses'] = ['org2']
     expected_result['staff']['course_limited_access'] = ['course-v1:ORG2+2+2']
     assert get_all_course_access_roles()[3] == expected_result
 
@@ -581,13 +581,13 @@ def test_get_usernames_with_access_roles(base_data):  # pylint: disable=unused-a
     assert user3.is_active is True
     expected_result = ['user1', 'user2', 'user3', 'user4', 'user8', 'user9', 'user60']
 
-    assert set(get_usernames_with_access_roles(['ORG1', 'ORG2'])) == set(expected_result)
+    assert set(get_usernames_with_access_roles(['org1', 'org2'])) == set(expected_result)
 
     user3.is_active = False
     user3.save()
     expected_result.remove('user3')
-    assert set(get_usernames_with_access_roles(['ORG1', 'ORG2'], active_filter=True)) == set(expected_result)
-    assert get_usernames_with_access_roles(['ORG1', 'ORG2'], active_filter=False) == ['user3']
+    assert set(get_usernames_with_access_roles(['org1', 'org2'], active_filter=True)) == set(expected_result)
+    assert get_usernames_with_access_roles(['org1', 'org2'], active_filter=False) == ['user3']
 
 
 def test_role_types():
@@ -607,7 +607,7 @@ def test_get_roles_for_users_queryset_bad_exclude(bad_role_type, expected_error_
     """Verify that get_roles_for_users_queryset raises an error if the exclude parameter is invalid."""
     with pytest.raises(TypeError) as exc_info:
         get_course_access_roles_queryset(
-            orgs_filter=['ORG1', 'ORG2'],
+            orgs_filter=['org1', 'org2'],
             remove_redundant=False,
             exclude_role_type=bad_role_type,
         )
@@ -618,7 +618,7 @@ def test_get_roles_for_users_queryset_bad_course_id():
     """Verify that get_roles_for_users_queryset raises an error if the course_id parameter is invalid."""
     with pytest.raises(ValueError) as exc_info:
         get_course_access_roles_queryset(
-            orgs_filter=['ORG1', 'ORG2'],
+            orgs_filter=['org1', 'org2'],
             remove_redundant=False,
             course_ids_filter=['course-v1:ORG1+999+999', 'course-v1:ORG1+bad_course_id', 'course-v1:ORG1+99+99'],
         )
@@ -631,11 +631,11 @@ def roles_records_to_dict(records):
         record.user.username: {} for record in records
     }
     for record in records:
-        result[record.user.username][record.org] = {}
+        result[record.user.username][record.org.lower()] = {}
     for record in records:
-        result[record.user.username][record.org][str(record.course_id or 'None')] = []
+        result[record.user.username][record.org.lower()][str(record.course_id or 'None')] = []
     for record in records:
-        result[record.user.username][record.org][str(record.course_id or 'None')].append(record.role)
+        result[record.user.username][record.org.lower()][str(record.course_id or 'None')].append(record.role)
 
     return result
 
@@ -694,13 +694,13 @@ def test_get_roles_for_users_queryset_roles_filter(base_data):  # pylint: disabl
 
     expected_data = {
         'user9': {
-            'ORG3': {
+            'org3': {
                 'None': ['data_researcher'],
                 'course-v1:ORG3+2+2': ['data_researcher'],
             },
         },
         'user10': {
-            'ORG3': {'None': ['data_researcher']},
+            'org3': {'None': ['data_researcher']},
         },
 
     }
@@ -709,7 +709,7 @@ def test_get_roles_for_users_queryset_roles_filter(base_data):  # pylint: disabl
     result = get_course_access_roles_queryset(
         orgs_filter=get_all_orgs(), remove_redundant=True, roles_filter=['data_researcher']
     )
-    del expected_data['user9']['ORG3']['course-v1:ORG3+2+2']
+    del expected_data['user9']['org3']['course-v1:ORG3+2+2']
     assert roles_records_to_dict(result) == expected_data
 
 
@@ -718,101 +718,101 @@ def test_get_roles_for_users_queryset_roles_filter(base_data):  # pylint: disabl
     ([], False, None, get_test_data_dict()),
     ([], True, None, {
         'user3': {
-            'ORG1': {
+            'org1': {
                 'None': ['staff'],
                 'course-v1:ORG1+3+3': ['org_course_creator_group'],
                 'course-v1:ORG1+4+4': ['org_course_creator_group'],
             }
         },
         'user8': {
-            'ORG2': {'None': ['staff'], 'course-v1:ORG2+3+3': ['org_course_creator_group']}
+            'org2': {'None': ['staff'], 'course-v1:ORG2+3+3': ['org_course_creator_group']}
         },
         'user9': {
-            'ORG3': {
+            'org3': {
                 'None': ['staff', 'data_researcher'],
                 'course-v1:ORG3+3+3': ['org_course_creator_group'],
             },
-            'ORG2': {'course-v1:ORG2+1+1': ['staff'], 'course-v1:ORG2+3+3': ['staff']},
+            'org2': {'course-v1:ORG2+1+1': ['staff'], 'course-v1:ORG2+3+3': ['staff']},
         },
-        'user18': {'ORG3': {'None': ['staff']}},
+        'user18': {'org3': {'None': ['staff']}},
         'user10': {
-            'ORG4': {'None': ['staff']},
-            'ORG3': {'None': ['data_researcher']},
+            'org4': {'None': ['staff']},
+            'org3': {'None': ['data_researcher']},
         },
         'user23': {
-            'ORG4': {'None': ['staff', 'org_course_creator_group']},
-            'ORG5': {'None': ['staff', 'org_course_creator_group']},
-            'ORG8': {'None': ['org_course_creator_group']},
+            'org4': {'None': ['staff', 'org_course_creator_group']},
+            'org5': {'None': ['staff', 'org_course_creator_group']},
+            'org8': {'None': ['org_course_creator_group']},
         },
         'user4': {
-            'ORG1': {'None': ['org_course_creator_group'], 'course-v1:ORG1+4+4': ['staff']},
-            'ORG2': {'None': ['org_course_creator_group']},
-            'ORG3': {
+            'org1': {'None': ['org_course_creator_group'], 'course-v1:ORG1+4+4': ['staff']},
+            'org2': {'None': ['org_course_creator_group']},
+            'org3': {
                 'None': ['org_course_creator_group'],
                 'course-v1:ORG3+1+1': ['staff'],
             },
         },
         'user11': {
-            'ORG3': {
+            'org3': {
                 'course-v1:ORG3+2+2': ['org_course_creator_group'],
             }
         },
-        'user48': {'ORG4': {'None': ['org_course_creator_group']}},
+        'user48': {'org4': {'None': ['org_course_creator_group']}},
     }),
     ([], False, RoleType.ORG_WIDE, {
         'user3': {
-            'ORG1': {
+            'org1': {
                 'course-v1:ORG1+3+3': ['staff', 'org_course_creator_group'],
                 'course-v1:ORG1+4+4': ['org_course_creator_group'],
             }
         },
         'user8': {
-            'ORG2': {'course-v1:ORG2+3+3': ['org_course_creator_group']}
+            'org2': {'course-v1:ORG2+3+3': ['org_course_creator_group']}
         },
         'user9': {
-            'ORG3': {
+            'org3': {
                 'course-v1:ORG3+2+2': ['data_researcher'],
                 'course-v1:ORG3+3+3': ['org_course_creator_group'],
             },
-            'ORG2': {'course-v1:ORG2+1+1': ['staff'], 'course-v1:ORG2+3+3': ['staff']},
+            'org2': {'course-v1:ORG2+1+1': ['staff'], 'course-v1:ORG2+3+3': ['staff']},
         },
-        'user18': {'ORG3': {'course-v1:ORG3+3+3': ['staff']}},
+        'user18': {'org3': {'course-v1:ORG3+3+3': ['staff']}},
         'user4': {
-            'ORG1': {'course-v1:ORG1+4+4': ['staff']},
-            'ORG3': {
+            'org1': {'course-v1:ORG1+4+4': ['staff']},
+            'org3': {
                 'course-v1:ORG3+1+1': ['staff', 'org_course_creator_group'],
             },
         },
         'user11': {
-            'ORG3': {
+            'org3': {
                 'course-v1:ORG3+2+2': ['org_course_creator_group'],
             }
         },
     }),
     ([], True, RoleType.ORG_WIDE, {
         'user3': {
-            'ORG1': {
+            'org1': {
                 'course-v1:ORG1+3+3': ['org_course_creator_group'],
                 'course-v1:ORG1+4+4': ['org_course_creator_group'],
             }
         },
         'user8': {
-            'ORG2': {'course-v1:ORG2+3+3': ['org_course_creator_group']}
+            'org2': {'course-v1:ORG2+3+3': ['org_course_creator_group']}
         },
         'user9': {
-            'ORG3': {
+            'org3': {
                 'course-v1:ORG3+3+3': ['org_course_creator_group'],
             },
-            'ORG2': {'course-v1:ORG2+1+1': ['staff'], 'course-v1:ORG2+3+3': ['staff']},
+            'org2': {'course-v1:ORG2+1+1': ['staff'], 'course-v1:ORG2+3+3': ['staff']},
         },
         'user4': {
-            'ORG1': {'course-v1:ORG1+4+4': ['staff']},
-            'ORG3': {
+            'org1': {'course-v1:ORG1+4+4': ['staff']},
+            'org3': {
                 'course-v1:ORG3+1+1': ['staff'],
             },
         },
         'user11': {
-            'ORG3': {
+            'org3': {
                 'course-v1:ORG3+2+2': ['org_course_creator_group'],
             }
         },
@@ -821,68 +821,68 @@ def test_get_roles_for_users_queryset_roles_filter(base_data):  # pylint: disabl
     ([], True, RoleType.COURSE_SPECIFIC, get_test_data_dict_without_course_roles()),
     (['course-v1:ORG3+2+2'], False, None, {
         'user9': {
-            'ORG3': {
+            'org3': {
                 'None': ['staff', 'data_researcher'],
                 'course-v1:ORG3+2+2': ['data_researcher'],
             },
         },
-        'user18': {'ORG3': {'None': ['staff']}},
+        'user18': {'org3': {'None': ['staff']}},
         'user10': {
-            'ORG3': {'None': ['data_researcher']},
+            'org3': {'None': ['data_researcher']},
         },
         'user23': {
-            'ORG8': {'None': ['org_course_creator_group']},
+            'org8': {'None': ['org_course_creator_group']},
         },
         'user4': {
-            'ORG3': {
+            'org3': {
                 'None': ['org_course_creator_group'],
             },
         },
         'user11': {
-            'ORG3': {
+            'org3': {
                 'course-v1:ORG3+2+2': ['org_course_creator_group'],
             }
         },
     }),
     (['course-v1:ORG3+2+2'], True, None, {
         'user9': {
-            'ORG3': {
+            'org3': {
                 'None': ['staff', 'data_researcher'],
             },
         },
-        'user18': {'ORG3': {'None': ['staff']}},
+        'user18': {'org3': {'None': ['staff']}},
         'user10': {
-            'ORG3': {'None': ['data_researcher']},
+            'org3': {'None': ['data_researcher']},
         },
         'user23': {
-            'ORG8': {'None': ['org_course_creator_group']},
+            'org8': {'None': ['org_course_creator_group']},
         },
         'user4': {
-            'ORG3': {
+            'org3': {
                 'None': ['org_course_creator_group'],
             },
         },
         'user11': {
-            'ORG3': {
+            'org3': {
                 'course-v1:ORG3+2+2': ['org_course_creator_group'],
             }
         },
     }),
     (['course-v1:ORG3+2+2'], False, RoleType.ORG_WIDE, {
         'user9': {
-            'ORG3': {
+            'org3': {
                 'course-v1:ORG3+2+2': ['data_researcher'],
             },
         },
         'user11': {
-            'ORG3': {
+            'org3': {
                 'course-v1:ORG3+2+2': ['org_course_creator_group'],
             }
         },
     }),
     (['course-v1:ORG3+2+2'], True, RoleType.ORG_WIDE, {
         'user11': {
-            'ORG3': {
+            'org3': {
                 'course-v1:ORG3+2+2': ['org_course_creator_group'],
             }
         },
@@ -917,7 +917,7 @@ def test_get_roles_for_users_queryset(
 @pytest.mark.django_db
 def test_get_roles_for_users_queryset_superuser(base_data):  # pylint: disable=unused-argument
     """Verify that get_roles_for_users_queryset does not include superusers."""
-    test_orgs = ['ORG1', 'ORG2']
+    test_orgs = ['org1', 'org2']
     user = get_user_model().objects.get(username='user1')
     assert user.is_superuser is True
 
@@ -931,7 +931,7 @@ def test_get_roles_for_users_queryset_superuser(base_data):  # pylint: disable=u
 @pytest.mark.django_db
 def test_get_roles_for_users_queryset_staff(base_data):  # pylint: disable=unused-argument
     """Verify that get_roles_for_users_queryset does not include staff user."""
-    test_orgs = ['ORG1', 'ORG2']
+    test_orgs = ['org1', 'org2']
     user = get_user_model().objects.get(username='user2')
     assert user.is_superuser is False
     assert user.is_staff is True
@@ -954,7 +954,7 @@ def assert_roles_result(result, expected):
     for index in range(expected_length):
         assert result[index].user_id == expected[index]['user_id']
         assert result[index].role == expected[index]['role']
-        assert result[index].org == expected[index]['org']
+        assert result[index].org.lower() == expected[index]['org'].lower()
         assert str(result[index].course_id) == expected[index]['course_id']
 
 
@@ -963,21 +963,21 @@ def test_get_roles_for_users_queryset_remove_redundant(base_data):  # pylint: di
     """
     Verify that get_roles_for_users_queryset returns the expected queryset, with or without redundant records.
     """
-    test_orgs = ['ORG1', 'ORG2']
+    test_orgs = ['org1', 'org2']
     user = get_user_model().objects.get(username='user3')
     assert CourseAccessRole.objects.filter(org__in=test_orgs, user__in=[user]).count() == 4
 
     result = get_course_access_roles_queryset(orgs_filter=test_orgs, remove_redundant=False, users=[user])
     assert_roles_result(result, [
-        {'user_id': 3, 'role': 'org_course_creator_group', 'org': 'ORG1', 'course_id': 'course-v1:ORG1+3+3'},
-        {'user_id': 3, 'role': 'org_course_creator_group', 'org': 'ORG1', 'course_id': 'course-v1:ORG1+4+4'},
-        {'user_id': 3, 'role': 'staff', 'org': 'ORG1', 'course_id': 'None'},
-        {'user_id': 3, 'role': 'staff', 'org': 'ORG1', 'course_id': 'course-v1:ORG1+3+3'},
+        {'user_id': 3, 'role': 'org_course_creator_group', 'org': 'org1', 'course_id': 'course-v1:ORG1+3+3'},
+        {'user_id': 3, 'role': 'org_course_creator_group', 'org': 'org1', 'course_id': 'course-v1:ORG1+4+4'},
+        {'user_id': 3, 'role': 'staff', 'org': 'org1', 'course_id': 'None'},
+        {'user_id': 3, 'role': 'staff', 'org': 'org1', 'course_id': 'course-v1:ORG1+3+3'},
     ])
 
     result = get_course_access_roles_queryset(orgs_filter=test_orgs, remove_redundant=True, users=[user])
     assert_roles_result(result, [
-        {'user_id': 3, 'role': 'org_course_creator_group', 'org': 'ORG1', 'course_id': 'course-v1:ORG1+3+3'},
-        {'user_id': 3, 'role': 'org_course_creator_group', 'org': 'ORG1', 'course_id': 'course-v1:ORG1+4+4'},
-        {'user_id': 3, 'role': 'staff', 'org': 'ORG1', 'course_id': 'None'},
+        {'user_id': 3, 'role': 'org_course_creator_group', 'org': 'org1', 'course_id': 'course-v1:ORG1+3+3'},
+        {'user_id': 3, 'role': 'org_course_creator_group', 'org': 'org1', 'course_id': 'course-v1:ORG1+4+4'},
+        {'user_id': 3, 'role': 'staff', 'org': 'org1', 'course_id': 'None'},
     ])

--- a/tests/test_helpers/test_tenants.py
+++ b/tests/test_helpers/test_tenants.py
@@ -104,11 +104,11 @@ def test_get_all_course_org_filter_list(base_data):  # pylint: disable=unused-ar
     """Verify get_all_course_org_filter_list function."""
     result = tenants.get_all_course_org_filter_list()
     assert result == {
-        1: ['ORG1', 'ORG2'],
-        2: ['ORG3', 'ORG8'],
-        3: ['ORG4', 'ORG5'],
-        7: ['ORG3'],
-        8: ['ORG8'],
+        1: ['org1', 'org2'],
+        2: ['org3', 'org8'],
+        3: ['org4', 'org5'],
+        7: ['org3'],
+        8: ['org8'],
     }
 
 
@@ -125,7 +125,7 @@ def test_get_all_course_org_filter_list_is_being_cached():
 @pytest.mark.django_db
 @pytest.mark.parametrize('tenant_ids, expected', [
     ([1, 2, 3, 7], {
-        'course_org_filter_list': ['ORG1', 'ORG2', 'ORG3', 'ORG8', 'ORG4', 'ORG5'],
+        'course_org_filter_list': ['org1', 'org2', 'org3', 'org8', 'org4', 'org5'],
         'duplicates': {
             2: [7],
             7: [2],
@@ -133,17 +133,17 @@ def test_get_all_course_org_filter_list_is_being_cached():
         'invalid': [],
     }),
     ([2, 3], {
-        'course_org_filter_list': ['ORG3', 'ORG8', 'ORG4', 'ORG5'],
+        'course_org_filter_list': ['org3', 'org8', 'org4', 'org5'],
         'duplicates': {},
         'invalid': [],
     }),
     ([2, 3, 4], {
-        'course_org_filter_list': ['ORG3', 'ORG8', 'ORG4', 'ORG5'],
+        'course_org_filter_list': ['org3', 'org8', 'org4', 'org5'],
         'duplicates': {},
         'invalid': [4],
     }),
     ([2, 3, 7, 8], {
-        'course_org_filter_list': ['ORG3', 'ORG8', 'ORG4', 'ORG5'],
+        'course_org_filter_list': ['org3', 'org8', 'org4', 'org5'],
         'duplicates': {
             2: [7, 8],
             7: [2],
@@ -274,16 +274,17 @@ def test_get_tenant_site(base_data, tenant_id, expected):  # pylint: disable=unu
 
 @pytest.mark.django_db
 @pytest.mark.parametrize('org, expected', [
-    ('ORG1', [1]),
-    ('ORG2', [1]),
-    ('ORG3', [2, 7]),
-    ('ORG4', [3]),
-    ('ORG5', [3]),
-    ('ORG8', [2, 8]),
+    ('org1', [1]),
+    ('org2', [1]),
+    ('org3', [2, 7]),
+    ('org4', [3]),
+    ('org5', [3]),
+    ('org8', [2, 8]),
 ])
 def test_get_tenants_by_org(base_data, org, expected):  # pylint: disable=unused-argument
     """Verify get_tenants_by_org function."""
-    assert expected == tenants.get_tenants_by_org(org)
+    assert len(expected) == len(tenants.get_tenants_by_org(org))
+    assert set(expected) == set(tenants.get_tenants_by_org(org))
 
 
 @pytest.mark.django_db
@@ -337,9 +338,9 @@ def test_get_user_id_from_username_tenants_bad_tenant(base_data, tenant_ids):  #
 
 @pytest.mark.django_db
 @pytest.mark.parametrize('username, tenant_ids, orgs, sites, is_enrolled, is_signup', [
-    ('user15', [1], ['ORG1', 'ORG2'], ['s1.sample.com'], True, False),
-    ('user50', [7], ['ORG3'], ['s7.sample.com'], False, True),
-    ('user4', [1], ['ORG1', 'ORG2'], ['s1.sample.com'], True, True),
+    ('user15', [1], ['org1', 'org2'], ['s1.sample.com'], True, False),
+    ('user50', [7], ['org3'], ['s7.sample.com'], False, True),
+    ('user4', [1], ['org1', 'org2'], ['s1.sample.com'], True, True),
 ])
 def test_get_user_id_from_username_tenants(
     base_data, username, tenant_ids, orgs, sites, is_enrolled, is_signup
@@ -382,7 +383,7 @@ def test_get_user_id_from_username_tenants_inactive_enrollment(base_data):  # py
     assert tenants.get_user_id_from_username_tenants(username, tenant_ids) == int(username[len('user'):])
     CourseEnrollment.objects.filter(
         user__username=username,
-        course__org__in=['ORG1', 'ORG2'],
+        course__org__in=['org1', 'org2'],
     ).update(is_active=False)
     assert tenants.get_user_id_from_username_tenants(username, tenant_ids) == int(username[len('user'):])
 


### PR DESCRIPTION
* fix: key and collation of `CourseAccessRole` in tests: SQLite is performing `in` operations as case-sensitive unless it is explicitly defined as `NOCASE`. We need to test scenarios where `org` in roles is not the same as the one in organizations (case-sensitivity-wise)
* fix: test-data to include case-insensitive orgs: this will pinpoint python code that compares orgs as case-sensitive
* fix: `CourseAccessRole` is always case-insensitive