### PR TITLE
refactor: Better use of UserSignupSource

### DIFF
--- a/futurex_openedx_extensions/__init__.py
+++ b/futurex_openedx_extensions/__init__.py
@@ -1,3 +1,3 @@
 """One-line description for README and other doc files."""
 
-__version__ = '0.8.11'
+__version__ = '0.8.12'

--- a/futurex_openedx_extensions/dashboard/views.py
+++ b/futurex_openedx_extensions/dashboard/views.py
@@ -101,11 +101,9 @@ class TotalCountsView(APIView, FXViewRoleInfoMixin):
         return sum(org_count['courses_count'] for org_count in collector_result)
 
     @staticmethod
-    def _get_learners_count_data(one_tenant_permission_info: dict, tenant_id: int, include_staff: bool) -> int:
+    def _get_learners_count_data(one_tenant_permission_info: dict, include_staff: bool) -> int:
         """Get the count of learners for the given tenant"""
-        collector_result = get_learners_count(one_tenant_permission_info, include_staff=include_staff)
-        return collector_result[tenant_id]['learners_count'] + \
-            collector_result[tenant_id]['learners_count_no_enrollment']
+        return get_learners_count(one_tenant_permission_info, include_staff=include_staff)
 
     def _get_stat_count(self, stat: str, tenant_id: int, include_staff: bool) -> int:
         """Get the count of the given stat for the given tenant"""
@@ -119,7 +117,7 @@ class TotalCountsView(APIView, FXViewRoleInfoMixin):
         if stat == self.STAT_HIDDEN_COURSES:
             return self._get_courses_count_data(one_tenant_permission_info, visible_filter=False)
 
-        return self._get_learners_count_data(one_tenant_permission_info, tenant_id, include_staff)
+        return self._get_learners_count_data(one_tenant_permission_info, include_staff)
 
     def get(self, request: Any, *args: Any, **kwargs: Any) -> Response | JsonResponse:
         """

--- a/futurex_openedx_extensions/helpers/querysets.py
+++ b/futurex_openedx_extensions/helpers/querysets.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from typing import List
 
-from common.djangoapps.student.models import CourseAccessRole, UserSignupSource
+from common.djangoapps.student.models import CourseAccessRole
 from django.db.models import BooleanField, Case, Exists, OuterRef, Q, Value, When
 from django.db.models.query import QuerySet
 from django.utils.timezone import now
@@ -140,20 +140,3 @@ def get_base_queryset_courses(
         q_set = q_set.filter(course_is_visible=visible_filter)
 
     return q_set
-
-
-def get_has_site_login_queryset(tenant_sites: List[str]) -> Exists:
-    """
-    Get the queryset of users who have logged in to any of the given tenant sites.
-
-    :param tenant_sites: List of tenant sites to check for
-    :type tenant_sites: List[str]
-    :return: QuerySet of users
-    :rtype: Exists
-    """
-    return Exists(
-        UserSignupSource.objects.filter(
-            user_id=OuterRef('id'),
-            site__in=tenant_sites
-        )
-    )

--- a/tests/base_test_data.py
+++ b/tests/base_test_data.py
@@ -293,13 +293,13 @@ _base_data = {
 
 
 expected_statistics = {
-    '1': {'certificates_count': 14, 'courses_count': 12, 'hidden_courses_count': 0, 'learners_count': 17},
-    '2': {'certificates_count': 9, 'courses_count': 5, 'hidden_courses_count': 0, 'learners_count': 22},
+    '1': {'certificates_count': 14, 'courses_count': 12, 'hidden_courses_count': 0, 'learners_count': 16},
+    '2': {'certificates_count': 9, 'courses_count': 5, 'hidden_courses_count': 0, 'learners_count': 21},
     '3': {'certificates_count': 0, 'courses_count': 1, 'hidden_courses_count': 0, 'learners_count': 6},
-    '7': {'certificates_count': 7, 'courses_count': 3, 'hidden_courses_count': 0, 'learners_count': 18},
+    '7': {'certificates_count': 7, 'courses_count': 3, 'hidden_courses_count': 0, 'learners_count': 17},
     '8': {'certificates_count': 2, 'courses_count': 2, 'hidden_courses_count': 0, 'learners_count': 9},
     'total_certificates_count': 32,
     'total_courses_count': 23,
     'total_hidden_courses_count': 0,
-    'total_learners_count': 72
+    'total_learners_count': 69,
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,7 +12,7 @@ from lms.djangoapps.certificates.models import GeneratedCertificate
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 
 from tests.base_test_data import _base_data
-from tests.fixture_helpers import get_user1_fx_permission_info
+from tests.fixture_helpers import get_tenants_of_org, get_user1_fx_permission_info
 
 
 @pytest.fixture
@@ -53,6 +53,7 @@ def roles_authorize_caller():
 def base_data(django_db_setup, django_db_blocker):  # pylint: disable=unused-argument, too-many-statements
     """Create base data for tests."""
     def _get_course_id(org, course_index):
+        """Get course ID."""
         return f'course-v1:{org}+{course_index}+{course_index}'
 
     def _create_users():
@@ -186,6 +187,16 @@ def base_data(django_db_setup, django_db_blocker):  # pylint: disable=unused-arg
                         course_id=course_id,
                         is_active=True,
                     )
+                    for _tenant_id in get_tenants_of_org(org, _base_data['tenant_config']):
+                        assert 0 < _tenant_id < 9, f'Bad tenant_id in enrollment testing data for org: {org}'
+                        if _tenant_id == 6:
+                            continue
+                        _site = _base_data['routes'][_tenant_id]['domain']
+                        if _site:
+                            UserSignupSource.objects.get_or_create(
+                                site=_site,
+                                user_id=user_id,
+                            )
 
     def _create_certificates():
         """Create certificates."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -191,12 +191,10 @@ def base_data(django_db_setup, django_db_blocker):  # pylint: disable=unused-arg
                         assert 0 < _tenant_id < 9, f'Bad tenant_id in enrollment testing data for org: {org}'
                         if _tenant_id == 6:
                             continue
-                        _site = _base_data['routes'][_tenant_id]['domain']
-                        if _site:
-                            UserSignupSource.objects.get_or_create(
-                                site=_site,
-                                user_id=user_id,
-                            )
+                        UserSignupSource.objects.get_or_create(
+                            site=_base_data['routes'][_tenant_id]['domain'],
+                            user_id=user_id,
+                        )
 
     def _create_certificates():
         """Create certificates."""

--- a/tests/fixture_helpers.py
+++ b/tests/fixture_helpers.py
@@ -41,6 +41,20 @@ def get_tenants_orgs(tenant_id):
     return list(result)
 
 
+def get_tenants_of_org(org, base_data_tenant_config):
+    """Get tenants of an organization."""
+    result = set()
+    for tenant_id, tenant_info in base_data_tenant_config.items():
+        if isinstance(tenant_info['lms_configs']['course_org_filter'], str):
+            _course_org_filter = [tenant_info['lms_configs']['course_org_filter']]
+        else:
+            _course_org_filter = tenant_info['lms_configs']['course_org_filter']
+        for _org in _course_org_filter:
+            if _org.lower() == org.lower():
+                result.add(tenant_id)
+    return list(result)
+
+
 def set_user(request, user_id=1):
     """Set user for request."""
     if user_id is None:

--- a/tests/test_dashboard/test_details/test_details_learners.py
+++ b/tests/test_dashboard/test_details/test_details_learners.py
@@ -151,8 +151,8 @@ def test_get_learners_search_queryset_active_filter(
 
 @pytest.mark.django_db
 @pytest.mark.parametrize('tenant_ids, expected_count', [
-    ([7, 8], 23),
-    ([7], 18),
+    ([7, 8], 26),
+    ([7], 20),
     ([4], 0),
 ])
 def test_get_learners_queryset(

--- a/tests/test_dashboard/test_details/test_details_learners.py
+++ b/tests/test_dashboard/test_details/test_details_learners.py
@@ -166,7 +166,6 @@ def test_get_learners_queryset(
     if expected_count > 0:
         assert result.first().courses_count is not None, 'courses_count should be in the queryset'
         assert result.first().certificates_count is not None, 'certificates_count should be in the queryset'
-        assert result.first().has_site_login is not None, 'has_site_login should be in the queryset'
 
 
 @pytest.mark.django_db

--- a/tests/test_dashboard/test_statistics/test_learners.py
+++ b/tests/test_dashboard/test_statistics/test_learners.py
@@ -1,184 +1,26 @@
 """Tests for learners statistics."""
-from unittest.mock import Mock
 
 import pytest
-from common.djangoapps.student.models import CourseEnrollment, UserSignupSource
 
 from futurex_openedx_extensions.dashboard.statistics import learners
+from futurex_openedx_extensions.helpers.permissions import get_tenant_limited_fx_permission_info
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize('tenant_id, expected_result', [
-    (1, {'org1': 4, 'org2': 17}),
-    (2, {'org3': 14, 'org8': 6}),
-    (3, {'org4': 4}),
-    (7, {'org3': 14}),
-    (8, {'org8': 6}),
+@pytest.mark.parametrize('tenant_id, expected_result_no_staff, expected_result_include_staff', [
+    (1, 16, 18),
+    (2, 21, 26),
+    (3, 6, 6),
+    (7, 17, 20),
+    (8, 9, 10),
 ])
-def test_get_learners_count_having_enrollment_per_org(
-    base_data, user1_fx_permission_info, tenant_id, expected_result
+def test_get_learners_count(
+    base_data, user1_fx_permission_info, tenant_id, expected_result_no_staff, expected_result_include_staff,
 ):  # pylint: disable=unused-argument
-    """Test get_learners_count_having_enrollment_per_org function."""
-    result = learners.get_learners_count_having_enrollment_per_org(user1_fx_permission_info, tenant_id)
-    assert result.count() == len(expected_result), 'Wrong number of organizations returned'
-
-    for result_tenant_id in result:
-        assert result_tenant_id['org_lower_case'] in expected_result, \
-            f'Unexpected org: {result_tenant_id["org_lower_case"]}'
-        assert result_tenant_id['learners_count'] == expected_result[result_tenant_id['org_lower_case']], \
-            f'Wrong learners count: {result_tenant_id["learners_count"]}, org: {result_tenant_id["org_lower_case"]}'
-
-
-@pytest.mark.django_db
-def test_get_learners_count_having_enrollment_per_org_inactive_enrollment(
-    base_data, user1_fx_permission_info
-):  # pylint: disable=unused-argument
-    """Verify that inactive enrollments are not counted by get_learners_count_having_enrollment_per_org."""
-    enrollment = CourseEnrollment.objects.get(user_id=21, course_id='course-v1:ORG1+5+5')
-    assert enrollment.is_active is True, 'bad test data'
-    tenant1_org1 = learners.get_learners_count_having_enrollment_per_org(
-        user1_fx_permission_info, 1
-    )
-    assert tenant1_org1[0]['org_lower_case'] == 'org1', 'bad test data'
-    assert tenant1_org1[0]['learners_count'] == 4, 'bad test data'
-
-    enrollment.is_active = False
-    enrollment.save()
-    tenant1_org1 = learners.get_learners_count_having_enrollment_per_org(
-        user1_fx_permission_info, 1
-    )
-    assert tenant1_org1[0]['org_lower_case'] == 'org1', 'bad test data'
-    assert tenant1_org1[0]['learners_count'] == 3, 'inactive enrollment should not be counted'
-
-
-@pytest.mark.django_db
-@pytest.mark.parametrize('tenant_id, expected_result', [
-    (1, 17),
-    (2, 17),
-    (3, 4),
-    (7, 14),
-    (8, 6),
-])
-def test_get_learners_count_having_enrollment_for_tenant(
-    base_data, user1_fx_permission_info, tenant_id, expected_result
-):  # pylint: disable=unused-argument
-    """Test get_learners_count_having_enrollment_for_tenant function."""
-    result = learners.get_learners_count_having_enrollment_for_tenant(user1_fx_permission_info, tenant_id)
-    assert result == expected_result, f'Wrong learners count: {result} for tenant: {tenant_id}'
-
-
-@pytest.mark.django_db
-def test_get_learners_count_having_enrollment_for_tenant_inactive_enrollment(
-    base_data, user1_fx_permission_info
-):  # pylint: disable=unused-argument
-    """Verify that get_learners_count_having_enrollment_for_tenant is not counting inactive enrollments."""
-    enrollments = CourseEnrollment.objects.filter(user_id=21, course__org__in=['org1', 'org2'])
-    assert enrollments.filter(is_active=True).count() == 3, 'bad test data'
-    assert enrollments.filter(is_active=False).count() == 0, 'bad test data'
-    assert learners.get_learners_count_having_enrollment_for_tenant(user1_fx_permission_info, 1) == 17, \
-        'bad test data'
-
-    enrollments.update(is_active=False)
-    assert learners.get_learners_count_having_enrollment_for_tenant(user1_fx_permission_info, 1) == 16, \
-        'inactive enrollment should not be counted'
-
-
-@pytest.mark.django_db
-@pytest.mark.parametrize('tenant_id, expected_result', [
-    (1, 0),
-    (2, 5),
-    (3, 2),
-    (7, 4),
-    (8, 3),
-])
-def test_get_learners_count_having_no_enrollment(
-    base_data, user1_fx_permission_info, tenant_id, expected_result
-):  # pylint: disable=unused-argument
-    """Test get_learners_count_having_no_enrollment function."""
-    result = learners.get_learners_count_having_no_enrollment(user1_fx_permission_info, tenant_id)
-    assert result == expected_result, f'Wrong learners count: {result} for tenant: {tenant_id}'
-
-
-@pytest.mark.django_db
-def test_get_learners_count_having_no_enrollment_without_full_access_to_tenant():
-    """Test get_learners_count_having_no_enrollment function without full access to tenant."""
-    tenant_id = 2
-    fx_permission_info = {
-        'user': Mock(username='dummy'),
-        'is_system_staff_user': True,
-        'user_roles': [],
-        'permitted_tenant_ids': [tenant_id],
-        'view_allowed_roles': [],
-        'view_allowed_full_access_orgs': ['org3', 'org8'],
-        'view_allowed_course_access_orgs': [],
-    }
-    assert learners.get_learners_count_having_no_enrollment(fx_permission_info, tenant_id) > 0
-    fx_permission_info.update({
-        'is_system_staff_user': False,
-        'view_allowed_full_access_orgs': ['org3'],
-        'view_allowed_course_access_orgs': ['org8'],
-    })
-    assert learners.get_learners_count_having_no_enrollment(fx_permission_info, tenant_id) == 0
-
-
-@pytest.mark.django_db
-def test_get_learners_count_having_no_enrollment_inactive_enrollment(
-    base_data, user1_fx_permission_info
-):  # pylint: disable=unused-argument
-    """Verify that get_learners_count_having_no_enrollment is counting inactive enrollments correctly."""
-    user_id = 5
-    enrollments = CourseEnrollment.objects.filter(user_id=user_id, course__org__in=['org1', 'org2'])
-    signup = UserSignupSource.objects.filter(user_id=user_id, site='s1.sample.com')
-    assert enrollments.filter(is_active=True).count() == 2, 'bad test data'
-    assert enrollments.filter(is_active=False).count() == 0, 'bad test data'
-    assert signup.count() == 1, 'bad test data'
-    assert learners.get_learners_count_having_no_enrollment(user1_fx_permission_info, 1) == 0, 'bad test data'
-
-    enrollment = enrollments.first()
-    enrollment.is_active = False
-    enrollment.save()
-    assert learners.get_learners_count_having_no_enrollment(user1_fx_permission_info, 1) == 0, \
-        'having inactive enrollments should not include the user from the count if there are other active enrollments'
-
-    enrollments.update(is_active=False)
-    assert learners.get_learners_count_having_no_enrollment(user1_fx_permission_info, 1) == 1, \
-        'users with at least one inactive enrollment, and no active enrollments should be counted'
-
-
-@pytest.mark.django_db
-def test_get_learners_count(base_data, user1_fx_permission_info):  # pylint: disable=unused-argument
     """Test get_learners_count function."""
-    expected_result = {
-        1: {'learners_count': 17, 'learners_count_no_enrollment': 0},
-        2: {'learners_count': 17, 'learners_count_no_enrollment': 5},
-        3: {'learners_count': 4, 'learners_count_no_enrollment': 2},
-        7: {'learners_count': 14, 'learners_count_no_enrollment': 4},
-        8: {'learners_count': 6, 'learners_count_no_enrollment': 3}
-    }
-    result = learners.get_learners_count(user1_fx_permission_info)
-    assert result == expected_result, f'Wrong learners count: {result}'
+    tenant_fx_permission_info = get_tenant_limited_fx_permission_info(user1_fx_permission_info, tenant_id)
+    result = learners.get_learners_count(tenant_fx_permission_info)
+    assert result == expected_result_no_staff, f'Wrong learners count: {result}'
 
-    result = learners.get_learners_count(user1_fx_permission_info, calculate_per_org=True)
-    for tenant_id, tenant_info in expected_result.items():
-        tenant_info['learners_count_per_org'] = {
-            1: {'org1': 4, 'org2': 17},
-            2: {'org3': 14, 'org8': 6},
-            3: {'org4': 4},
-            7: {'org3': 14},
-            8: {'org8': 6}
-        }[tenant_id]
-    assert result == expected_result, f'Wrong learners count: {result}'
-
-
-@pytest.mark.django_db
-def test_get_learners_count_include_staff(base_data, user1_fx_permission_info):  # pylint: disable=unused-argument
-    """Test get_learners_count function."""
-    result = learners.get_learners_count(user1_fx_permission_info, calculate_per_org=True, include_staff=True)
-
-    assert result == {
-        1: {'learners_count': 18, 'learners_count_no_enrollment': 2, 'learners_count_per_org': {'org1': 6, 'org2': 18}},
-        2: {'learners_count': 20, 'learners_count_no_enrollment': 6, 'learners_count_per_org': {'org3': 16, 'org8': 7}},
-        3: {'learners_count': 4, 'learners_count_no_enrollment': 2, 'learners_count_per_org': {'org4': 4}},
-        7: {'learners_count': 16, 'learners_count_no_enrollment': 4, 'learners_count_per_org': {'org3': 16}},
-        8: {'learners_count': 7, 'learners_count_no_enrollment': 3, 'learners_count_per_org': {'org8': 7}}
-    }
+    result = learners.get_learners_count(tenant_fx_permission_info, include_staff=True)
+    assert result == expected_result_include_staff

--- a/tests/test_dashboard/test_views.py
+++ b/tests/test_dashboard/test_views.py
@@ -99,11 +99,11 @@ class TestTotalCountsView(BaseTestViewMixin):
         self.assertTrue(isinstance(response, JsonResponse))
         self.assertEqual(response.status_code, http_status.HTTP_200_OK)
         expected_response = {
-            '1': {'certificates_count': 14, 'courses_count': 12, 'learners_count': 17},
-            '2': {'certificates_count': 9, 'courses_count': 5, 'learners_count': 22},
+            '1': {'certificates_count': 14, 'courses_count': 12, 'learners_count': 16},
+            '2': {'certificates_count': 9, 'courses_count': 5, 'learners_count': 21},
             'total_certificates_count': 23,
             'total_courses_count': 17,
-            'total_learners_count': 39
+            'total_learners_count': 37,
         }
         self.assertDictEqual(json.loads(response.content), expected_response)
 

--- a/tests/test_helpers/test_querysets.py
+++ b/tests/test_helpers/test_querysets.py
@@ -111,26 +111,6 @@ def test_get_base_queryset_courses_global_roles(base_data, fx_permission_info): 
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize('sites, expected', [
-    (['s1.sample.com'], True),
-    (['s2.sample.com'], True),
-    (['s3.sample.com'], False),
-    (['s1.sample.com', 's2.sample.com'], True),
-    (['s1.sample.com', 's3.sample.com'], True),
-    (['s2.sample.com', 's3.sample.com'], True),
-])
-def test_get_has_site_login_queryset(base_data, sites, expected):  # pylint: disable=unused-argument
-    """Verify get_has_site_login_queryset function."""
-    result = get_user_model().objects.filter(
-        username='user4',
-    ).annotate(
-        has_site_login=querysets.get_has_site_login_queryset(sites),
-    )
-    assert result.count() == 1
-    assert result.first().has_site_login == expected
-
-
-@pytest.mark.django_db
 @pytest.mark.parametrize('argument_name, bad_value, expected_error_msg', [
     ('ref_user_id', None, 'Invalid ref_user_id type (NoneType)'),
     ('ref_org', 0, 'Invalid ref_org type (int)'),


### PR DESCRIPTION
We now have `UserSignupSource` filled on course-enrollment! refactoring a few functions accordingly 

- **refactor: use UserSignupSource to count learners in tenants**: this will also enhance performance
- **refactor: get_user_id_from_username_tenants**: to use UserSignupSource for better performance
- **refactor: get_learners_queryset to use UserSignupSource**: just filter on UserSignupSource for better performance

