### PR TITLE
Add 'completion rate' to courses list api

### DIFF
--- a/futurex_openedx_extensions/dashboard/details/courses.py
+++ b/futurex_openedx_extensions/dashboard/details/courses.py
@@ -9,6 +9,7 @@ from django.db.models import (
     DateTimeField,
     Exists,
     F,
+    FloatField,
     IntegerField,
     Max,
     OuterRef,
@@ -130,6 +131,12 @@ def get_courses_queryset(
             ).values('course_id').annotate(count=Count('id')).values('count'),
             output_field=IntegerField(),
         ), 0),
+    ).annotate(
+        completion_rate=Case(
+            When(enrolled_count=0, then=Value(0.0)),
+            default=F('certificates_count') * 1.0 / F('enrolled_count'),
+            output_field=FloatField(),
+        )
     )
 
     return queryset

--- a/futurex_openedx_extensions/dashboard/serializers.py
+++ b/futurex_openedx_extensions/dashboard/serializers.py
@@ -286,6 +286,7 @@ class CourseDetailsSerializer(CourseDetailsBaseSerializer):
     enrolled_count = serializers.IntegerField()
     active_count = serializers.IntegerField()
     certificates_count = serializers.IntegerField()
+    completion_rate = serializers.FloatField()
 
     class Meta:
         model = CourseOverview
@@ -294,6 +295,7 @@ class CourseDetailsSerializer(CourseDetailsBaseSerializer):
             'enrolled_count',
             'active_count',
             'certificates_count',
+            'completion_rate',
         ]
 
     def get_rating(self, obj: CourseOverview) -> Any:  # pylint: disable=no-self-use

--- a/futurex_openedx_extensions/dashboard/views.py
+++ b/futurex_openedx_extensions/dashboard/views.py
@@ -184,7 +184,7 @@ class CoursesView(ListAPIView, FXViewRoleInfoMixin):
     filter_backends = [DefaultOrderingFilter]
     ordering_fields = [
         'id', 'self_paced', 'enrolled_count', 'active_count',
-        'certificates_count', 'display_name', 'org',
+        'certificates_count', 'display_name', 'org', 'completion_rate',
     ]
     ordering = ['display_name']
     fx_view_name = 'courses_list'

--- a/tests/test_dashboard/test_serializers.py
+++ b/tests/test_dashboard/test_serializers.py
@@ -273,12 +273,14 @@ def test_course_details_serializer(base_data):  # pylint: disable=unused-argumen
     course.enrolled_count = 10
     course.active_count = 5
     course.certificates_count = 3
+    course.completion_rate = 0.3
     course.save()
     data = CourseDetailsSerializer(course).data
     assert data['id'] == str(course.id)
     assert data['enrolled_count'] == course.enrolled_count
     assert data['active_count'] == course.active_count
     assert data['certificates_count'] == course.certificates_count
+    assert data['completion_rate'] == course.completion_rate
 
 
 @pytest.mark.django_db
@@ -303,6 +305,7 @@ def test_course_details_serializer_rating(
     course.enrolled_count = 1
     course.active_count = 1
     course.certificates_count = 1
+    course.completion_rate = 1
     course.save()
     data = CourseDetailsSerializer(course).data
     assert data['rating'] == expected_rating


### PR DESCRIPTION
**Related Issue:** https://github.com/nelc/futurex-openedx-extensions/issues/60

**API**: GET <LMS_URL>/api/fx/courses/v1/courses/

Update courses list API to return completion rate.

**SS from local setup:**
![image](https://github.com/user-attachments/assets/3169006b-8ef8-4992-aa45-64aafd52ecdf)
