### PR TITLE
feat: add enrollments count statistics

### DIFF
--- a/futurex_openedx_extensions/dashboard/views.py
+++ b/futurex_openedx_extensions/dashboard/views.py
@@ -170,6 +170,8 @@ class TotalCountsView(APIView, FXViewRoleInfoMixin):
                 result[tenant_id][self.STAT_RESULT_KEYS[stat]] = count
                 result[f'total_{self.STAT_RESULT_KEYS[stat]}'] += count
 
+        result['limited_access'] = self.fx_permission_info['view_allowed_course_access_orgs'] != []
+
         return JsonResponse(result)
 
 

--- a/tests/base_test_data.py
+++ b/tests/base_test_data.py
@@ -293,13 +293,44 @@ _base_data = {
 
 
 expected_statistics = {
-    '1': {'certificates_count': 14, 'courses_count': 12, 'hidden_courses_count': 0, 'learners_count': 16},
-    '2': {'certificates_count': 9, 'courses_count': 5, 'hidden_courses_count': 0, 'learners_count': 21},
-    '3': {'certificates_count': 0, 'courses_count': 1, 'hidden_courses_count': 0, 'learners_count': 6},
-    '7': {'certificates_count': 7, 'courses_count': 3, 'hidden_courses_count': 0, 'learners_count': 17},
-    '8': {'certificates_count': 2, 'courses_count': 2, 'hidden_courses_count': 0, 'learners_count': 9},
+    '1': {
+        'certificates_count': 14,
+        'courses_count': 12,
+        'enrollments_count': 26,
+        'hidden_courses_count': 0,
+        'learners_count': 16,
+    },
+    '2': {
+        'certificates_count': 9,
+        'courses_count': 5,
+        'enrollments_count': 21,
+        'hidden_courses_count': 0,
+        'learners_count': 21,
+    },
+    '3': {
+        'certificates_count': 0,
+        'courses_count': 1,
+        'enrollments_count': 4,
+        'hidden_courses_count': 0,
+        'learners_count': 6,
+    },
+    '7': {
+        'certificates_count': 7,
+        'courses_count': 3,
+        'enrollments_count': 14,
+        'hidden_courses_count': 0,
+        'learners_count': 17,
+    },
+    '8': {
+        'certificates_count': 2,
+        'courses_count': 2,
+        'enrollments_count': 7,
+        'hidden_courses_count': 0,
+        'learners_count': 9,
+    },
     'total_certificates_count': 32,
     'total_courses_count': 23,
+    'total_enrollments_count': 72,
     'total_hidden_courses_count': 0,
     'total_learners_count': 69,
 }

--- a/tests/base_test_data.py
+++ b/tests/base_test_data.py
@@ -333,4 +333,5 @@ expected_statistics = {
     'total_enrollments_count': 72,
     'total_hidden_courses_count': 0,
     'total_learners_count': 69,
+    'limited_access': False,
 }

--- a/tests/test_dashboard/test_statistics/test_courses.py
+++ b/tests/test_dashboard/test_statistics/test_courses.py
@@ -37,6 +37,24 @@ def test_get_courses_count(base_data, fx_permission_info):  # pylint: disable=un
 
 
 @pytest.mark.django_db
+def test_get_enrollments_count(base_data, fx_permission_info):  # pylint: disable=unused-argument
+    """Verify get_enrollments_count function."""
+    result = courses.get_enrollments_count(fx_permission_info, include_staff=True)
+
+    assert list(result) == [
+        {'org_lower_case': 'org1', 'enrollments_count': 9},
+        {'org_lower_case': 'org2', 'enrollments_count': 23},
+    ]
+
+    result = courses.get_enrollments_count(fx_permission_info)
+
+    assert list(result) == [
+        {'org_lower_case': 'org1', 'enrollments_count': 4},
+        {'org_lower_case': 'org2', 'enrollments_count': 22},
+    ]
+
+
+@pytest.mark.django_db
 def test_get_courses_count_by_status(base_data, fx_permission_info):  # pylint: disable=unused-argument
     """Verify get_courses_count_by_status function."""
     result = courses.get_courses_count_by_status(fx_permission_info)

--- a/tests/test_dashboard/test_views.py
+++ b/tests/test_dashboard/test_views.py
@@ -87,7 +87,7 @@ class TestTotalCountsView(BaseTestViewMixin):
     def test_all_stats(self):
         """Test get method"""
         self.login_user(self.staff_user)
-        response = self.client.get(self.url + '?stats=certificates,courses,hidden_courses,learners')
+        response = self.client.get(self.url + '?stats=certificates,courses,hidden_courses,learners,enrollments')
         self.assertTrue(isinstance(response, JsonResponse))
         self.assertEqual(response.status_code, http_status.HTTP_200_OK)
         self.assertDictEqual(json.loads(response.content), expected_statistics)

--- a/tests/test_dashboard/test_views.py
+++ b/tests/test_dashboard/test_views.py
@@ -92,6 +92,14 @@ class TestTotalCountsView(BaseTestViewMixin):
         self.assertEqual(response.status_code, http_status.HTTP_200_OK)
         self.assertDictEqual(json.loads(response.content), expected_statistics)
 
+    def test_limited_access(self):
+        """Test get method with limited access"""
+        self.login_user(3)
+        response = self.client.get(self.url + '?stats=certificates')  # we need at least one stat
+        self.assertTrue(isinstance(response, JsonResponse))
+        self.assertEqual(response.status_code, http_status.HTTP_200_OK)
+        self.assertEqual(json.loads(response.content)['limited_access'], True)
+
     def test_selected_tenants(self):
         """Test get method with selected tenants"""
         self.login_user(self.staff_user)
@@ -104,6 +112,7 @@ class TestTotalCountsView(BaseTestViewMixin):
             'total_certificates_count': 23,
             'total_courses_count': 17,
             'total_learners_count': 37,
+            'limited_access': False,
         }
         self.assertDictEqual(json.loads(response.content), expected_response)
 


### PR DESCRIPTION
**feat: add enrollments count statistics**

a new option in statistics-totals API to give the total number of enrollments in the given tenants and accessible courses

```
GET api/fx/statistics/v1/total_counts/?stats=enrollments
```

**feat: add limited_access flag to statistics API**

an extra field in the response:
```json
{
  ...
  "limited_access": false
}
```
the value is `true` if the user has only course-specific roles in the given tenants