### PR TITLE
feat: add my-roles API

### DIFF
--- a/futurex_openedx_extensions/__init__.py
+++ b/futurex_openedx_extensions/__init__.py
@@ -1,3 +1,3 @@
 """One-line description for README and other doc files."""
 
-__version__ = '0.8.16'
+__version__ = '0.8.18'

--- a/futurex_openedx_extensions/dashboard/urls.py
+++ b/futurex_openedx_extensions/dashboard/urls.py
@@ -33,6 +33,7 @@ urlpatterns = [
         views.LearnerCoursesView.as_view(),
         name='learner-courses'
     ),
+    re_path(r'^api/fx/roles/v1/my_roles/$', views.MyRolesView.as_view(), name='my-roles'),
     re_path(r'^api/fx/roles/v1/', include(router.urls)),
     re_path(r'^api/fx/statistics/v1/course_statuses/$', views.CourseStatusesView.as_view(), name='course-statuses'),
     re_path(r'^api/fx/statistics/v1/rating/$', views.GlobalRatingView.as_view(), name='statistics-rating'),

--- a/futurex_openedx_extensions/dashboard/views.py
+++ b/futurex_openedx_extensions/dashboard/views.py
@@ -37,6 +37,7 @@ from futurex_openedx_extensions.helpers import clickhouse_operations as ch
 from futurex_openedx_extensions.helpers.constants import (
     CLICKHOUSE_FX_BUILTIN_CA_USERS_OF_TENANTS,
     CLICKHOUSE_FX_BUILTIN_ORG_IN_TENANTS,
+    COURSE_ACCESS_ROLES_SUPPORTED_READ,
     COURSE_STATUS_SELF_PREFIX,
     COURSE_STATUSES,
 )
@@ -571,6 +572,22 @@ class UserRolesManagementView(viewsets.ModelViewSet, FXViewRoleInfoMixin):  # py
             )
 
         return Response(status=http_status.HTTP_204_NO_CONTENT)
+
+
+class MyRolesView(APIView, FXViewRoleInfoMixin):
+    """View to get the user roles of the caller"""
+    permission_classes = [FXHasTenantCourseAccess]
+    fx_view_name = 'my_roles'
+    fx_default_read_only_roles = COURSE_ACCESS_ROLES_SUPPORTED_READ.copy()
+    fx_view_description = 'api/fx/roles/v1/my_roles/: user roles management APIs'
+
+    serializer_class = serializers.UserRolesSerializer
+
+    def get(self, request: Any, *args: Any, **kwargs: Any) -> JsonResponse:
+        """Get the list of users"""
+        data = serializers.UserRolesSerializer(self.fx_permission_info['user'], context={'request': request}).data
+        data['is_system_staff'] = self.fx_permission_info['is_system_staff_user']
+        return JsonResponse(data)
 
 
 class ClickhouseQueryView(APIView, FXViewRoleInfoMixin):


### PR DESCRIPTION
feat: add my-roles API

All tenants:
```
GET api/fx/roles/v1/my_roles/
```

or specific tenants:
```
GET api/fx/roles/v1/my_roles/?tenant_ids=4
```

It'll work and return a result as long as the user is a system-staff, or has at least one role in the tenant. The result is the same one from get-users-roles API, but for one record with no list. Example:
```json
{
    "user_id": 12,
    "email": "shadinaif+2@gmail.com",
    "username": "shadinaif",
    "full_name": "Shadi Naif",
    "alternative_full_name": "",
    "is_staff_user": false,
    "global_roles": [],
    "tenants": {
        "4": {
            "tenant_roles": [
                "data_researcher"
            ],
            "course_roles": {}
        }
    }
}
```