### PR TITLE
feat: implement Optional Fields

### DIFF
--- a/futurex_openedx_extensions/dashboard/custom_serializers.py
+++ b/futurex_openedx_extensions/dashboard/custom_serializers.py
@@ -1,0 +1,173 @@
+"""Custom Serializers for the dashboard APIs."""
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from rest_framework import serializers
+
+
+class ExcludedOptionalField:  # pylint: disable=too-few-public-methods
+    """Class for excluded optional fields."""
+
+
+class OptionalFieldsSerializerMixin:  # pylint: disable=too-few-public-methods
+    """
+    Mixin to support optional fields.
+
+    Optional fields are seamlessly integrated into the serializer like any other field!
+
+    The optional fields are not included in the response unless they are explicitly requested via query_params. The
+    request for the optional fields is made by providing a comma-separated list of tags, not field names. The same tag
+    can be used for multiple fields. The tags are case-insensitive, with one shared between all fields by default
+    named `__all__`.
+
+    For an API endpoint that supports optional fields, the query_params can look like this:
+    `?optional_field_tags=tag1,tag2,tag3`
+
+    The optional fields functionality can be used with GET requests only. The logic is ignored for all other requests
+    methods.
+
+    How to use it?
+    There are two ways to use this functionality. Whatever way you choose, the following steps are required, note that
+        these are all normal django-rest-framework practices:
+        * The optional fields must be defined as `SerializerOptionalMethodField` fields.
+            * The `field_tags` parameter is mandatory and must be a list of strings, or an empty list.
+        * The related method must be defined in the serializer normally. ex `def get_field_name(self, instance):`.
+            * No special handling is required for the method.
+        * The optional fields must be added to the serializer's `Meta.fields` list normally.
+
+    First (recommended): use it along with the `ModelSerializerOptionalFields` serializer. Or more specifically, with
+    a serializer that has `OptionalFieldsSerializerMixin` in its inheritance chain.
+        * The related method of the optional field will not be processed unless explicitly requested via query_params.
+        * The optional fields will not be included in the response unless explicitly requested via query_params.
+        * The optional fields will not be included in the response if the `field_tags` parameter is an empty list.
+        * The optional fields are requested by providing a comma-separated list of tags, not field names.
+
+    Second: use it with any other serializer. This means that query_params will not be accessible in the context.
+        Therefore, the optional fields will not be processed, unless you manually provide the
+        `requested_optional_field_tags` in the context during the creation of the serializer. For example:
+        ```
+        serializer = AnySerializer(instance, context={'requested_optional_field_tags': ['tag1', 'tag2']})
+        ```
+        * The related method of the optional field will not be processed unless explicitly requested.
+            * If not requested, the field's result-value will be defaulted.
+        * The optional fields will always be included in the response.
+        * So, without `OptionalFieldsSerializerMixin`, the optional fields will act like an optionally-processed field
+            rather than an optional field.
+
+    Here is a simple breakdown of how it's technically working:
+    * `ModelSerializerOptionalFields` uses `ListSerializerOptionalFields` as the `list_serializer_class` that adds
+        support for optional fields in listing mode (many=True).
+    * `ModelSerializerOptionalFields` initializes the `optional_field_names` as an empty list.
+    * `ModelSerializerOptionalFields` saves the requested optional field tags in the context under the key
+        `requested_optional_field_tags`. The `GET request` object must be provided in the context during the serializer
+        creation. Otherwise, the logic of remove-optional-fields-from-final-result will be ignored.
+    * `ModelSerializerOptionalFields.to_representation` processes the super's representation which will collect the
+        data from the methods and fields normally.
+        * `SerializerOptionalMethodField` initializes the `field_tags` parameter as a set of tags that were provided
+            during the field's definition. Plus a shared tag named `__all__`.
+        * When the parent serializer calls the field's `bind` method during the render,
+            `SerializerOptionalMethodField.bind` will add the field name to the `optional_field_names` list of the
+            parent serializer, unless the parent serializer is not inherited from `OptionalFieldsSerializerMixin`.
+        * `SerializerOptionalMethodField.to_representation` will check for `requested_optional_field_tags` in the
+            context and return the value if (at least) one of the field's tags is in the requested tags. Otherwise:
+            - parent is inherited from `OptionalFieldsSerializerMixin`: it will return an instance
+                of `ExcludedOptionalField` to tell the parent that the field is to be removed from the final result.
+            - parent is not inherited from `OptionalFieldsSerializerMixin`: it will return the default of the field
+    * `ModelSerializerOptionalFields.to_representation` continues to process the representation and removes the optional
+        fields from the final result if they are instances of `ExcludedOptionalField`.
+    * Seamless integration of optional fields is achieved!
+    """
+    optional_field_tags_key = 'optional_field_tags'
+
+    def __init__(self, *args: Any, **kwargs: Any):
+        """Initialize the serializer."""
+        self.optional_field_names: list = []
+
+        if kwargs.get('context', {}).get('request') and kwargs['context']['request'].method == 'GET':
+            requested_optional_field_tags = kwargs['context']['request'].query_params.get(
+                self.optional_field_tags_key, '',
+            ).split(',')
+            kwargs['context']['requested_optional_field_tags'] = list({
+                tag.strip().lower() for tag in requested_optional_field_tags if tag and tag.strip()
+            })
+
+        super().__init__(*args, **kwargs)
+
+    def _remove_optional_fields(self, representation: dict[str, Any]) -> None:
+        """Remove the optional fields."""
+        for field_name in self.optional_field_names:
+            if isinstance(representation.get(field_name), ExcludedOptionalField):
+                representation.pop(field_name)
+
+    def to_representation(self, instance: Any) -> Any:
+        """Return the representation of the instance."""
+        representation = super().to_representation(instance)  # type: ignore
+
+        if getattr(self, 'many', False):
+            for item in representation:
+                self._remove_optional_fields(item)
+        else:
+            self._remove_optional_fields(representation)
+
+        return representation
+
+
+class ListSerializerOptionalFields(
+    OptionalFieldsSerializerMixin, serializers.ListSerializer,
+):  # pylint: disable=abstract-method
+    """List serializer for optional fields."""
+
+
+class ModelSerializerOptionalFields(OptionalFieldsSerializerMixin, serializers.ModelSerializer):
+    """Serializer for optional fields."""
+
+    class Meta:
+        list_serializer_class = ListSerializerOptionalFields
+
+
+class SerializerOptionalMethodField(serializers.SerializerMethodField):  # pylint: disable=abstract-method
+    """Serializer method field that is not processed unless explicitly requested via query_params."""
+    def __init__(self, field_tags: list, **kwargs: Any):
+        """Initialize the serializer method field."""
+        super().__init__(**kwargs)
+
+        if not isinstance(field_tags, list):
+            raise ValueError('SerializerOptionalMethodField: field_tags must be a list of strings.')
+
+        self._field_tags = {'__all__'}
+        self._removable = False
+
+        for field_name in field_tags:
+            if not isinstance(field_name, str):
+                raise ValueError('SerializerOptionalMethodField: field_tags must be a list of strings.')
+            field_name = field_name.strip().lower()
+            if not re.match(r'^[a-z][a-z0-9_-]+$', field_name):
+                raise ValueError(
+                    'SerializerOptionalMethodField: a tag must be at least two characters that start with an '
+                    'alphabetical character and contain only alphanumeric characters, underscores, and hyphens.'
+                )
+            self._field_tags.add(field_name)
+
+    def bind(self, field_name: str, parent: ModelSerializerOptionalFields) -> None:
+        """Bind the field."""
+        super().bind(field_name, parent)
+
+        if getattr(parent, 'optional_field_names', None) is not None:
+            parent.optional_field_names.append(field_name)
+            self._removable = True
+
+    @property
+    def field_tags(self) -> set:
+        """Return the field tags."""
+        return self._field_tags
+
+    def to_representation(self, value: Any) -> Any:
+        """Return the representation of the value."""
+        requested_optional_field_tags = self.context.get('requested_optional_field_tags', []) if self.context else []
+
+        if set(requested_optional_field_tags) & self.field_tags:
+            return super().to_representation(value)
+
+        return ExcludedOptionalField() if self._removable else self.default

--- a/tests/test_dashboard/test_custom_serializers.py
+++ b/tests/test_dashboard/test_custom_serializers.py
@@ -1,0 +1,152 @@
+"""Test serializers for dashboard app"""
+import copy
+from unittest.mock import Mock, patch
+
+import pytest
+from deepdiff import DeepDiff
+from rest_framework.fields import empty
+from rest_framework.serializers import ModelSerializer
+
+from futurex_openedx_extensions.dashboard.custom_serializers import (
+    ExcludedOptionalField,
+    ModelSerializerOptionalFields,
+    SerializerOptionalMethodField,
+)
+
+FIELD_FORMAT_ERROR = (
+    'a tag must be at least two characters that start with an alphabetical character and contain only '
+    'alphanumeric characters, underscores, and hyphens.'
+)
+
+
+def test_model_serializer_optional_fields_simple():
+    """Verify that the ModelSerializerOptionalFields correctly sets the optional fields."""
+    assert ModelSerializerOptionalFields.optional_field_tags_key == 'optional_field_tags'
+
+    serializer = ModelSerializerOptionalFields()
+    assert isinstance(serializer.optional_field_names, list)
+    assert not serializer.optional_field_names
+
+
+@pytest.mark.parametrize('query_params, method, expected_requested', [
+    ({}, 'GET', []),
+    ({'optional_field_tags': 'tag1,tag2'}, 'GET', ['tag1', 'tag2']),
+    ({'optional_field_tags': 'tag1,tag2'}, 'not_GET', []),
+    ({'optional_field_tags': 'tag1,tag2,tag1,Tag2,TAG3'}, 'GET', ['tag1', 'tag2', 'tag3']),
+])
+def test_model_serializer_optional_fields_requested(query_params, method, expected_requested):
+    """Verify that the ModelSerializerOptionalFields saves requested tags correctly."""
+    request = Mock(query_params=query_params, method=method)
+
+    serializer = ModelSerializerOptionalFields(context={'request': request})
+    assert not DeepDiff(
+        serializer.context.get('requested_optional_field_tags', []),
+        expected_requested,
+        ignore_order=True
+    )
+
+
+@pytest.mark.parametrize('many', [False, True])
+@patch('rest_framework.serializers.ModelSerializer.to_representation')
+def test_model_serializer_optional_fields_to_representation(mock_super_to_representation, many):
+    """Verify that the render of ModelSerializerOptionalFields works fine."""
+    request = Mock(query_params={'optional_field_tags': 'tag1,tag2'}, method='GET')
+    serializer = ModelSerializerOptionalFields(context={'request': request}, many=many)
+
+    expected_result = {
+        'field1': 'value1',
+        'field2': ExcludedOptionalField(),
+        'field3': 'value3',
+        'field4': ExcludedOptionalField(),
+    }
+    mock_super_to_representation.return_value = copy.deepcopy(expected_result)
+    result = serializer.to_representation(['data'] if many else 'data')
+    assert not DeepDiff(result, [expected_result] if many else expected_result, ignore_order=True)
+
+    serializer.optional_field_names = ['field1', 'field2']
+    mock_super_to_representation.return_value = copy.deepcopy(expected_result)
+    result = serializer.to_representation(['data'] if many else 'data')
+    expected_result.pop('field2')
+    assert not DeepDiff(result, [expected_result] if many else expected_result, ignore_order=True)
+
+
+def test_serializer_optional_method_field_simple():
+    """Verify that the SerializerOptionalMethodField initializes correctly."""
+    field = SerializerOptionalMethodField(field_tags=['tag1', 'tag2'])
+    assert not (field.field_tags ^ {'__all__', 'tag1', 'tag2'})
+
+
+@pytest.mark.parametrize('field_tags, expected_err_msg', [
+    ('not_list', 'field_tags must be a list of strings.'),
+    (None, 'field_tags must be a list of strings.'),
+    (['one_of_the_tags_is_not_str', {}], 'field_tags must be a list of strings.'),
+    (['_tag'], FIELD_FORMAT_ERROR),
+    (['1tag'], FIELD_FORMAT_ERROR),
+    (['t'], FIELD_FORMAT_ERROR),
+    (['tag!'], FIELD_FORMAT_ERROR),
+    (['t a g'], FIELD_FORMAT_ERROR),
+])
+def test_serializer_optional_method_field_invalid_field_tags(field_tags, expected_err_msg):
+    """Verify that the SerializerOptionalMethodField raises an exception on invalid field tags."""
+    with pytest.raises(ValueError) as exc_info:
+        SerializerOptionalMethodField(field_tags=field_tags)
+    assert str(exc_info.value) == f'SerializerOptionalMethodField: {expected_err_msg}'
+
+
+@patch('rest_framework.serializers.SerializerMethodField.bind')
+def test_serializer_optional_method_field_bind(mock_super_bind):
+    """Verify that the SerializerOptionalMethodField.bind correctly sets the optional field names."""
+    optional_fields_names = []
+    parent = Mock(optional_field_names=optional_fields_names, spec=ModelSerializerOptionalFields)
+    field = SerializerOptionalMethodField(field_tags=['tag1', 'tag2'])
+
+    assert not parent.optional_field_names
+    assert not field._removable  # pylint: disable=protected-access
+    field.bind('some_field_name', parent)
+
+    assert parent.optional_field_names == ['some_field_name']
+    assert field._removable  # pylint: disable=protected-access
+    mock_super_bind.assert_called_once_with('some_field_name', parent)
+
+
+def test_serializer_optional_method_field_bind_no_proper_parent():
+    """
+    Verify that the SerializerOptionalMethodField doesn't flag itself as removable if the parent doesn't
+    have the optional_field_names attribute.
+    """
+    not_model_serializer_optional_fields = ModelSerializer
+    parent = Mock(spec=not_model_serializer_optional_fields)
+    field = SerializerOptionalMethodField(field_tags=['tag1', 'tag2'])
+
+    assert getattr(parent, 'optional_field_names', None) is None
+    assert not field._removable  # pylint: disable=protected-access
+    field.bind('some_field_name', parent)
+
+    assert getattr(parent, 'optional_field_names', None) is None
+    assert not field._removable  # pylint: disable=protected-access
+
+
+@patch('rest_framework.serializers.SerializerMethodField.to_representation')
+def test_serializer_optional_method_field_invalid_field_to_representation_default(mock_super_representation):
+    """Verify that the SerializerOptionalMethodField """
+    field = SerializerOptionalMethodField(field_tags=['tag1', 'tag2'])
+    mock_super_representation.return_value = 'processed data'
+
+    assert field.to_representation('data') == empty, \
+        'The field should be defaulted'
+    mock_super_representation.assert_not_called()
+
+    field.root._context = {'requested_optional_field_tags': {'tag3'}}  # pylint: disable=protected-access
+    assert field.to_representation('data') == empty, \
+        'The field should be defaulted because the tag is not in the requested tags'
+    mock_super_representation.assert_not_called()
+
+    field._removable = True  # pylint: disable=protected-access
+    assert isinstance(field.to_representation('data'), ExcludedOptionalField), \
+        'The field should be excluded if flagged as removable'
+    mock_super_representation.assert_not_called()
+    mock_super_representation.reset_mock()
+
+    field.root._context = {'requested_optional_field_tags': {'tag1'}}  # pylint: disable=protected-access
+    assert field.to_representation('data') == 'processed data'
+    mock_super_representation.assert_called_once_with('data')


### PR DESCRIPTION
feat: implement Optional Fields

This will help us use the same endpoint and the same serializer to return extra fields in the result

One needed use-case is the need for extra columns in the exported files that are not available in the dashboard UI view. We don't include these columns (fields) because they need an intense process that will make the view very slow for no reason. But when these fields are explicitly requested; the view will include them in the result

For example, the following is a normal call to the API
```
GET /api/fx/learners/v1/learners/course-v1:ORG+1+1/
```

And the following has the same results above as a CSV download:
```
GET /api/fx/learners/v1/learners/course-v1:ORG+1+1/?download=csv
```

And the following is the same CSV download above, plus adding all extra fields to the export
```
GET /api/fx/learners/v1/learners/course-v1:ORG+1+1/?download=csv&optional_field_tags=__all__
```

Note: there are no extra fields implemented yet to the above API

_**The PR documents how to use the feature, and how it's technically working**_