### PR TITLE
feat: add library roles support for roles API

### DIFF
--- a/futurex_openedx_extensions/helpers/constants.py
+++ b/futurex_openedx_extensions/helpers/constants.py
@@ -29,10 +29,14 @@ CLICKHOUSE_FX_BUILTIN_CA_USERS_OF_TENANTS = '__ca_users_of_tenants__'
 
 CLICKHOUSE_QUERY_SLUG_PATTERN = r'[a-z0-9_\-.]+'
 
-COURSE_ID_PART = r'[a-zA-Z0-9_-]+'
+ID_PART = r'[a-zA-Z0-9_-]+'
 COURSE_ID_REGX = \
-    fr'(?P<course_id>course-v1:(?P<org>{COURSE_ID_PART})\+(?P<course>{COURSE_ID_PART})\+(?P<run>{COURSE_ID_PART}))'
+    fr'(?P<course_id>course-v1:(?P<org>{ID_PART})\+(?P<course>{ID_PART})\+(?P<run>{ID_PART}))'
 COURSE_ID_REGX_EXACT = rf'^{COURSE_ID_REGX}$'
+
+LIBRARY_ID_REGX = \
+    fr'(?P<course_id>library-v1:(?P<org>{ID_PART})\+(?P<code>{ID_PART}))'
+LIBRARY_ID_REGX_EXACT = rf'^{LIBRARY_ID_REGX}$'
 
 COURSE_STATUSES = {
     'active': 'active',
@@ -57,10 +61,12 @@ COURSE_ACCESS_ROLES_TENANT_ONLY = [
 ]
 
 COURSE_ACCESS_ROLES_STAFF_EDITOR = 'staff'
+COURSE_ACCESS_ROLES_LIBRARY_USER = 'library_user'
 
 COURSE_ACCESS_ROLES_TENANT_OR_COURSE = [
     'data_researcher',
     'instructor',
+    COURSE_ACCESS_ROLES_LIBRARY_USER,
     COURSE_ACCESS_ROLES_STAFF_EDITOR,
 ]
 COURSE_ACCESS_ROLES_GLOBAL = [
@@ -78,7 +84,6 @@ COURSE_ACCESS_ROLES_SUPPORTED_READ = COURSE_ACCESS_ROLES_SUPPORTED_EDIT + COURSE
 COURSE_ACCESS_ROLES_ACCEPT_COURSE_ID = COURSE_ACCESS_ROLES_COURSE_ONLY + COURSE_ACCESS_ROLES_TENANT_OR_COURSE
 
 COURSE_ACCESS_ROLES_UNSUPPORTED = [
-    'library_user',  # not supported yet, it requires a library ID instead of a course ID
     'sales_admin',  # won't be supported, looks like a deprecated role, there is no useful code for it
 ]
 

--- a/test_utils/edx_platform_mocks/xmodule/modulestore/django.py
+++ b/test_utils/edx_platform_mocks/xmodule/modulestore/django.py
@@ -1,0 +1,17 @@
+"""Mock modulestore"""
+from opaque_keys.edx.keys import CourseKey
+
+
+class DummyModuleStore:  # pylint: disable=too-few-public-methods
+    """DUmmy module store class"""
+    def __init__(self):
+        self.ids = ['library-v1:org1+11', 'library-v1:org1+22']
+
+    def get_library_keys(self):
+        """mock modulestore library keys method"""
+        return [CourseKey.from_string(id) for id in self.ids]
+
+
+def modulestore():
+    """mocked modulestore"""
+    return DummyModuleStore()


### PR DESCRIPTION
Add library roles and library_ids support for course access role APIs

Following are roles details
- staff role -> can be tenant wide or library specific.
- instructor role -> can be tenant wide or library specific.
- library_user -> only valid for library_ids, can not be set tenant wide.

Related Issue: https://github.com/nelc/futurex-openedx-extensions/issues/107