### PR TITLE
feat: add learners enrolment list api

### DIFF
--- a/futurex_openedx_extensions/dashboard/urls.py
+++ b/futurex_openedx_extensions/dashboard/urls.py
@@ -25,6 +25,9 @@ urlpatterns = [
         fr'^api/fx/learners/v1/learners/{COURSE_ID_REGX}/$',
         views.LearnersDetailsForCourseView.as_view(), name='learners-course'),
     re_path(
+        r'^api/fx/learners/v1/enrollments/$',
+        views.LearnersEnrollmentView.as_view(), name='learners-enrollements'),
+    re_path(
         r'^api/fx/learners/v1/learner/' + settings.USERNAME_PATTERN + '/$',
         views.LearnerInfoView.as_view(),
         name='learner-info'

--- a/tests/test_dashboard/test_views.py
+++ b/tests/test_dashboard/test_views.py
@@ -783,6 +783,31 @@ class TestLearnersDetailsForCourseView(BaseTestViewMixin):
         self.assertGreater(len(response.data['results']), 0)
 
 
+@pytest.mark.usefixtures('base_data')
+class TestLearnersEnrollmentView(BaseTestViewMixin):
+    """Tests for LearnersEnrollmentView"""
+    VIEW_NAME = 'fx_dashboard:learners-enrollements'
+
+    def test_unauthorized(self):
+        """Verify that the view returns 403 when the user is not authenticated"""
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, http_status.HTTP_403_FORBIDDEN)
+
+    def test_permission_classes(self):
+        """Verify that the view has the correct permission classes"""
+        view_func, _, _ = resolve(self.url)
+        view_class = view_func.view_class
+        self.assertEqual(view_class.permission_classes, [FXHasTenantCourseAccess])
+
+    def test_success(self):
+        """Verify that the view returns the correct response"""
+        self.login_user(self.staff_user)
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, http_status.HTTP_200_OK)
+        response = self.client.get(self.url, {'course_ids': 'course-v1:ORG1+5+5', 'user_ids': 15})
+        self.assertEqual(response.status_code, http_status.HTTP_200_OK)
+
+
 class MockClickhouseQuery:
     """Mock ClickhouseQuery"""
     def __init__(


### PR DESCRIPTION
Add enrollment api.

**Example usage:**

To get all enrolments:

`/api/fx/learners/v1/enrollments/`

```
[ 
    {
            "user_id": 10,
            "full_name": "user1",
            "alternative_full_name": "عالي",
            "username": "user1",
            "national_id": "",
            "email": "[user1@example.com](mailto:user1@example.com)",
            "mobile_no": null,
            "year_of_birth": null,
            "gender": "",
            "gender_display": null,
            "date_joined": "2024-11-08T12:31:06.322903Z",
            "last_login": "2024-11-15T08:23:03.539659Z",
            "certificate_available": false,
            "course_score": null,
            "active_in_course": false,
            "course_id": "course-v1:bragi_org+111+11"
        },
]
...
```

To get all enrolments - with complete details

`/api/fx/learners/v1/enrollments/?optional_field_tags=__all__`

```
[
    {
            "user_id": 10,
            "full_name": "user1",
            "alternative_full_name": "عالي",
            "username": "user1",
            "national_id": "",
            "email": "[user1@example.com](mailto:user1@example.com)",
            "mobile_no": null,
            "year_of_birth": null,
            "gender": "",
            "gender_display": null,
            "date_joined": "2024-11-08T12:31:06.322903Z",
            "last_login": "2024-11-15T08:23:03.539659Z",
            "certificate_available": false,
            "course_score": null,
            "active_in_course": false,
            "progress": 0.0,
            "certificate_url": null,
            "course_id": "course-v1:bragi_org+111+11",
            "earned - Final Exam: Subsection": "no attempt",
            "possible - Final Exam: Subsection": "no attempt",
            "earned - another: Subsection": "no attempt",
            "possible - another: Subsection": "no attempt"
    }.
...
]
```

To get all enrolments - for certain courses -> Send ',' separated list of course ids:

`/api/fx/learners/v1/enrollments/?course_ids=course_id1, course_id2`

To get all enrolments - for certain users -> Send ',' separated list of user ids:

`/api/fx/learners/v1/enrollments/?user_ids=1,2`

To get all enrolments - for specific user and course -> Send ',' separated list of user ids and course_ids:

`/api/fx/learners/v1/enrollments/?user_ids=1,2&course_ids=course_id1`

**Note**:
500 error will be raised for invalid course_ids.