### PR TITLE
feat: removable annotations on pagination

### DIFF
--- a/futurex_openedx_extensions/__init__.py
+++ b/futurex_openedx_extensions/__init__.py
@@ -1,3 +1,3 @@
 """One-line description for README and other doc files."""
 
-__version__ = '0.9.13'
+__version__ = '0.9.14'

--- a/futurex_openedx_extensions/helpers/apps.py
+++ b/futurex_openedx_extensions/helpers/apps.py
@@ -29,4 +29,6 @@ class HelpersConfig(AppConfig):
 
     def ready(self) -> None:
         """Connect handlers to send notifications about discussions."""
+        from futurex_openedx_extensions.helpers import \
+            monkey_patches  # pylint: disable=unused-import, import-outside-toplevel
         from futurex_openedx_extensions.helpers import signals  # pylint: disable=unused-import, import-outside-toplevel

--- a/futurex_openedx_extensions/helpers/exceptions.py
+++ b/futurex_openedx_extensions/helpers/exceptions.py
@@ -38,6 +38,8 @@ class FXExceptionCodes(Enum):
 
     SERIALIZER_FILED_NAME_DOES_NOT_EXIST = 7001
 
+    QUERY_SET_BAD_OPERATION = 8001
+
 
 class FXCodedException(Exception):
     """Exception with a code."""

--- a/futurex_openedx_extensions/helpers/monkey_patches.py
+++ b/futurex_openedx_extensions/helpers/monkey_patches.py
@@ -1,0 +1,21 @@
+"""Monkey patches defined here."""
+from __future__ import annotations
+
+from typing import Any
+
+from django.db.models.query import QuerySet
+
+original_queryset_chain = QuerySet._chain  # pylint: disable=protected-access
+
+
+def customized_queryset_chain(self: Any, **kwargs: Any) -> QuerySet:
+    """Customized queryset chain method for the QuerySet class."""
+    result = original_queryset_chain(self, **kwargs)
+
+    if hasattr(self, 'removable_annotations'):
+        result.removable_annotations = self.removable_annotations.copy()
+
+    return result
+
+
+QuerySet._chain = customized_queryset_chain  # pylint: disable=protected-access

--- a/futurex_openedx_extensions/helpers/pagination.py
+++ b/futurex_openedx_extensions/helpers/pagination.py
@@ -1,5 +1,27 @@
 """Pagination helpers and classes for the API views."""
+from django.core.paginator import Paginator
+from django.db.models.query import QuerySet
+from django.utils.functional import cached_property
 from rest_framework.pagination import PageNumberPagination
+
+from futurex_openedx_extensions.helpers.querysets import verify_queryset_removable_annotations
+
+
+class DefaultPaginator(Paginator):
+    """Default paginator settings for the API views."""
+    @cached_property
+    def count(self) -> int:
+        """Return the total number of objects, across all pages."""
+        if isinstance(self.object_list, QuerySet) and hasattr(self.object_list, 'removable_annotations'):
+            verify_queryset_removable_annotations(self.object_list)
+
+            clone = self.object_list._chain()  # pylint: disable=protected-access
+            for key in self.object_list.removable_annotations:
+                clone.query.annotations.pop(key, None)
+
+            return clone.count()
+
+        return super().count
 
 
 class DefaultPagination(PageNumberPagination):
@@ -7,3 +29,5 @@ class DefaultPagination(PageNumberPagination):
     page_size: int = 20
     page_size_query_param: str = 'page_size'
     max_page_size: int = 100
+
+    django_paginator_class = DefaultPaginator

--- a/futurex_openedx_extensions/helpers/querysets.py
+++ b/futurex_openedx_extensions/helpers/querysets.py
@@ -5,7 +5,7 @@ from typing import List
 
 from common.djangoapps.student.models import CourseAccessRole, CourseEnrollment, UserSignupSource
 from django.contrib.auth import get_user_model
-from django.db.models import BooleanField, Case, Exists, OuterRef, Q, Value, When
+from django.db.models import BooleanField, Case, Count, Exists, OuterRef, Q, Value, When
 from django.db.models.query import QuerySet
 from django.utils.timezone import now
 from opaque_keys.edx.django.models import CourseKeyField
@@ -16,6 +16,64 @@ from futurex_openedx_extensions.helpers.exceptions import FXCodedException, FXEx
 from futurex_openedx_extensions.helpers.extractors import get_partial_access_course_ids
 from futurex_openedx_extensions.helpers.tenants import get_tenants_sites
 from futurex_openedx_extensions.helpers.users import get_user_by_key
+
+
+def verify_queryset_removable_annotations(queryset: QuerySet) -> None:
+    """
+    Verify that the queryset has the removable annotations set.
+
+    :param queryset: QuerySet to verify
+    :type queryset: QuerySet
+    """
+    if not hasattr(queryset, 'removable_annotations'):
+        return
+
+    for key in queryset.removable_annotations:
+        if isinstance(queryset.query.annotations.get(key, None), Count):
+            raise FXCodedException(
+                code=FXExceptionCodes.QUERY_SET_BAD_OPERATION,
+                message=(
+                    f'Cannot set annotation `{key}` of type `Count` as removable. You must unset it from the '
+                    f'removable annotations list, or replace the `Count` annotation with `Subquery`.'
+                ),
+            )
+
+
+def update_removable_annotations(
+    queryset: QuerySet,
+    removable: set | List[str] | None = None,
+    not_removable: set | List[str] | None = None,
+) -> None:
+    """
+    Update the removable annotations on the given queryset.
+
+    :param queryset: QuerySet to update
+    :type queryset: QuerySet
+    :param removable: Set of annotations to add to the removable annotations
+    :type removable: set(str) | List[str] | None
+    :param not_removable: Set of annotations to remove from the removable annotations
+    :type not_removable: set(str) | List[str] | None
+    """
+    removable_annotations = queryset.removable_annotations if hasattr(queryset, 'removable_annotations') else set()
+    removable_annotations = (removable_annotations | set(removable or [])) - set(not_removable or [])
+
+    if not removable_annotations and hasattr(queryset, 'removable_annotations'):
+        del queryset.removable_annotations
+
+    elif removable_annotations:
+        queryset.removable_annotations = removable_annotations
+        verify_queryset_removable_annotations(queryset)
+
+
+def clear_removable_annotations(queryset: QuerySet) -> None:
+    """
+    Clear the removable annotations on the given queryset.
+
+    :param queryset: QuerySet to clear the removable annotations from
+    :type queryset: QuerySet
+    """
+    if hasattr(queryset, 'removable_annotations'):
+        del queryset.removable_annotations
 
 
 def check_staff_exist_queryset(

--- a/futurex_openedx_extensions/helpers/querysets.py
+++ b/futurex_openedx_extensions/helpers/querysets.py
@@ -195,11 +195,15 @@ def get_base_queryset_courses(
         ),
     )
 
+    update_removable_annotations(q_set, removable=['course_is_active', 'course_is_visible'])
+
     if active_filter is not None:
         q_set = q_set.filter(course_is_active=active_filter)
+        update_removable_annotations(q_set, not_removable=['course_is_active'])
 
     if visible_filter is not None:
         q_set = q_set.filter(course_is_visible=visible_filter)
+        update_removable_annotations(q_set, not_removable=['course_is_visible'])
 
     return q_set
 

--- a/tests/test_helpers/test_monkey_patches.py
+++ b/tests/test_helpers/test_monkey_patches.py
@@ -3,12 +3,13 @@ from unittest.mock import MagicMock, patch
 
 from django.db.models.query import QuerySet
 
-from futurex_openedx_extensions.helpers.monkey_patches import customized_queryset_chain
+from futurex_openedx_extensions.helpers.monkey_patches import customized_queryset_chain, original_queryset_chain
 
 
 def test_queryset_chain():
     """Verify that the original_queryset_chain is correctly defined."""
     assert QuerySet._chain == customized_queryset_chain  # pylint: disable=protected-access, comparison-with-callable
+    assert original_queryset_chain is not customized_queryset_chain
 
 
 @patch('futurex_openedx_extensions.helpers.monkey_patches.original_queryset_chain')

--- a/tests/test_helpers/test_monkey_patches.py
+++ b/tests/test_helpers/test_monkey_patches.py
@@ -1,0 +1,43 @@
+"""Tests for monkey patches"""
+from unittest.mock import MagicMock, patch
+
+from django.db.models.query import QuerySet
+
+from futurex_openedx_extensions.helpers.monkey_patches import customized_queryset_chain
+
+
+def test_queryset_chain():
+    """Verify that the original_queryset_chain is correctly defined."""
+    assert QuerySet._chain == customized_queryset_chain  # pylint: disable=protected-access, comparison-with-callable
+
+
+@patch('futurex_openedx_extensions.helpers.monkey_patches.original_queryset_chain')
+def test_customized_queryset_chain_has_attribute(mock_original_queryset_chain):
+    """Verify that the customized_queryset_chain is correctly defined."""
+    mock_original_queryset_chain.return_value = MagicMock(spec=QuerySet)
+    del mock_original_queryset_chain.return_value.removable_annotations
+
+    mock_queryset = MagicMock(spec=QuerySet)
+    mock_queryset.removable_annotations = {'annotation1'}
+    mock_queryset._chain.return_value = mock_queryset  # pylint: disable=protected-access
+
+    result = customized_queryset_chain(mock_queryset)
+    assert result.removable_annotations == mock_queryset.removable_annotations
+    mock_original_queryset_chain.assert_called_once_with(mock_queryset)
+
+
+@patch('futurex_openedx_extensions.helpers.monkey_patches.original_queryset_chain')
+def test_customized_queryset_chain_no_attribute(mock_original_queryset_chain):
+    """Verify that the customized_queryset_chain is correctly defined."""
+    mock_original_queryset_chain.return_value = MagicMock(spec=QuerySet)
+    delattr(  # pylint: disable=literal-used-as-attribute
+        mock_original_queryset_chain.return_value, 'removable_annotations',
+    )
+
+    mock_queryset = MagicMock(spec=QuerySet)
+    del mock_queryset.removable_annotations
+    mock_queryset._chain.return_value = mock_queryset  # pylint: disable=protected-access
+
+    result = customized_queryset_chain(mock_queryset)
+    assert not hasattr(result, 'removable_annotations')
+    mock_original_queryset_chain.assert_called_once_with(mock_queryset)

--- a/tests/test_helpers/test_pagination.py
+++ b/tests/test_helpers/test_pagination.py
@@ -1,7 +1,10 @@
 """Tests for pagination helpers"""
+from unittest.mock import MagicMock, PropertyMock, patch
+
+from django.db.models import QuerySet
 from rest_framework.pagination import PageNumberPagination
 
-from futurex_openedx_extensions.helpers.pagination import DefaultPagination
+from futurex_openedx_extensions.helpers.pagination import DefaultPagination, DefaultPaginator
 
 
 def test_default_pagination():
@@ -10,3 +13,55 @@ def test_default_pagination():
     assert DefaultPagination.page_size == 20
     assert DefaultPagination.page_size_query_param == 'page_size'
     assert DefaultPagination.max_page_size == 100
+    assert DefaultPagination.django_paginator_class == DefaultPaginator
+
+
+@patch('futurex_openedx_extensions.helpers.pagination.Paginator.count', new_callable=PropertyMock)
+@patch('futurex_openedx_extensions.helpers.pagination.verify_queryset_removable_annotations')
+def test_count_with_query_set_and_removable_annotations(mock_verify, mock_super_count):
+    """Verify that the count property is correctly defined."""
+    mock_super_count.return_value = 'should not be reached'
+
+    mock_queryset = MagicMock(spec=QuerySet)
+    mock_queryset.removable_annotations = {'annotation1'}
+    mock_queryset._chain.return_value = mock_queryset  # pylint: disable=protected-access
+    mock_queryset.query.annotations = {'annotation1': None, 'annotation2': None}
+    mock_queryset.count.return_value = 5
+
+    paginator = DefaultPaginator(mock_queryset, per_page=10)
+
+    assert paginator.count == 5
+    assert 'annotation1' not in mock_queryset.query.annotations
+    mock_super_count.assert_not_called()
+    mock_verify.assert_called_once_with(mock_queryset)
+
+
+@patch('futurex_openedx_extensions.helpers.pagination.Paginator.count', new_callable=PropertyMock)
+@patch('futurex_openedx_extensions.helpers.pagination.verify_queryset_removable_annotations')
+def test_count_with_query_set_no_removable_annotations(mock_verify, mock_super_count):
+    """Verify that the count property is correctly defined."""
+    mock_super_count.return_value = 44
+
+    mock_queryset = MagicMock(spec=QuerySet)
+    del mock_queryset.removable_annotations
+    mock_queryset.count.return_value = 'should not be reached'
+    mock_queryset.query.annotations = {'annotation1': None, 'annotation2': None}
+
+    paginator = DefaultPaginator(mock_queryset, per_page=10)
+
+    assert paginator.count == mock_super_count.return_value
+    assert mock_queryset.query.annotations == {'annotation1': None, 'annotation2': None}
+    mock_verify.assert_not_called()
+
+
+@patch('futurex_openedx_extensions.helpers.pagination.Paginator.count', new_callable=PropertyMock)
+@patch('futurex_openedx_extensions.helpers.pagination.verify_queryset_removable_annotations')
+def test_count_with_not_query_set(mock_verify, mock_super_count):
+    """Verify that the count property is correctly defined."""
+    mock_super_count.return_value = 44
+
+    object_list = 'not a queryset'
+    paginator = DefaultPaginator(object_list, per_page=10)
+
+    assert paginator.count == mock_super_count.return_value
+    mock_verify.assert_not_called()


### PR DESCRIPTION
* feat: removable annotations on pagination
* feat: apply removable annotations on applicable querysets
  * avoid using `Count` if removing the annotation is needed. Use `Subquery` instead