### PR TITLE
feat: ability to exclude global roles from GET-roles API

### DIFF
--- a/futurex_openedx_extensions/dashboard/serializers.py
+++ b/futurex_openedx_extensions/dashboard/serializers.py
@@ -682,20 +682,18 @@ class UserRolesSerializer(LearnerBasicDetailsSerializer):
         else:
             result['active_filter'] = None
 
-        exclude_tenant_roles = False
-        exclude_course_roles = False
-        if query_params.get('exclude_tenant_roles') is not None:
-            exclude_tenant_roles = query_params['exclude_tenant_roles'] == '1'
+        excluded_role_types = query_params.get('excluded_role_types', '').split(',') \
+            if query_params.get('excluded_role_types') else []
 
-        if not exclude_tenant_roles and query_params.get('exclude_course_roles') is not None:
-            exclude_course_roles = query_params['exclude_course_roles'] == '1'
+        result['excluded_role_types'] = []
+        if 'global' in excluded_role_types:
+            result['excluded_role_types'].append(RoleType.GLOBAL)
 
-        if exclude_tenant_roles:
-            result['exclude_role_type'] = RoleType.ORG_WIDE
-        elif exclude_course_roles:
-            result['exclude_role_type'] = RoleType.COURSE_SPECIFIC
-        else:
-            result['exclude_role_type'] = None
+        if 'tenant' in excluded_role_types:
+            result['excluded_role_types'].append(RoleType.ORG_WIDE)
+
+        if 'course' in excluded_role_types:
+            result['excluded_role_types'].append(RoleType.COURSE_SPECIFIC)
 
         return result
 
@@ -748,7 +746,7 @@ class UserRolesSerializer(LearnerBasicDetailsSerializer):
             roles_filter=self.query_params['roles_filter'],
             active_filter=self.query_params['active_filter'],
             course_ids_filter=self.query_params['course_ids_filter'],
-            exclude_role_type=self.query_params['exclude_role_type'],
+            excluded_role_types=self.query_params['excluded_role_types'],
         )
 
         for record in records or []:

--- a/futurex_openedx_extensions/dashboard/views.py
+++ b/futurex_openedx_extensions/dashboard/views.py
@@ -523,7 +523,7 @@ class UserRolesManagementView(viewsets.ModelViewSet, FXViewRoleInfoMixin):  # py
                     roles_filter=dummy_serializers.query_params['roles_filter'],
                     active_filter=dummy_serializers.query_params['active_filter'],
                     course_ids_filter=dummy_serializers.query_params['course_ids_filter'],
-                    exclude_role_type=dummy_serializers.query_params['exclude_role_type'],
+                    excluded_role_types=dummy_serializers.query_params['excluded_role_types'],
                 ).values('user_id').distinct().order_by()
             ).select_related('profile').order_by('id')
         except ValueError as exc:


### PR DESCRIPTION
feat: ability to exclude global roles from GET-roles API

* Removing exclusion filter options: `exclude_tenant_roles` and `exclude_course_roles`
* Replacing them with one exclusion filter option `excluded_role_types` that accepts any combination of `global`, `tenant`, and `course`

show only users having global roles ((do not show users having tenant-wise or course-specific roles, unless another role exists))
```
GET /api/fx/roles/v1/user_roles/?excluded_role_types=tenant,course
```

do not show users having global roles, unless another role exists
```
GET /api/fx/roles/v1/user_roles/?excluded_role_types=global
```

do not show users having course-specific roles, unless another role exists
```
GET /api/fx/roles/v1/user_roles/?excluded_role_types=course
```

invalid types are ignored. The following will act like the first example
```
GET /api/fx/roles/v1/user_roles/?excluded_role_types=atmoic,global
```

**Related Tasks:**

- [x] this is a breaking change, but filters for roles are not implemented yet in the front-end. Therefore, we're good 👍🏼 
- [x] update the docs!
