### PR TITLE
fix: global roles do not have access to views

### DIFF
--- a/futurex_openedx_extensions/helpers/roles.py
+++ b/futurex_openedx_extensions/helpers/roles.py
@@ -289,19 +289,23 @@ def get_accessible_tenant_ids(user: get_user_model, roles_filter: List[str] | No
     :return: List of accessible tenant IDs
     :rtype: List[int]
     """
+    all_tenant_ids = get_all_tenant_ids()
     if not user:
         return []
+
     if is_system_staff_user(user):
-        return get_all_tenant_ids()
+        return all_tenant_ids
 
     user_roles = get_user_course_access_roles(user.id)['roles']
-
     if roles_filter is None:
         roles_filter = list(user_roles.keys())
     elif not isinstance(roles_filter, list):
         raise TypeError('roles_filter must be a list')
     elif not roles_filter:
         return []
+
+    if set(cs.COURSE_ACCESS_ROLES_GLOBAL) & set(user_roles) & set(roles_filter):
+        return all_tenant_ids
 
     tenant_ids = set()
     for role_name in roles_filter:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,7 @@ from lms.djangoapps.certificates.models import GeneratedCertificate
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 from organizations.models import Organization
 
+from futurex_openedx_extensions.helpers import constants as cs
 from tests.base_test_data import _base_data
 from tests.fixture_helpers import get_tenants_of_org, get_user1_fx_permission_info
 
@@ -51,6 +52,18 @@ def fx_permission_info():
         'view_allowed_tenant_ids_any_access': [1],
         'view_allowed_tenant_ids_partial_access': [0],
     }
+
+
+@pytest.fixture
+def support_user():
+    """Fixture for support user."""
+    user_id = 55
+    assert CourseAccessRole.objects.filter(user_id=user_id).count() == 0, 'Bad test data'
+    user = get_user_model().objects.get(id=user_id)
+    assert not user.is_staff, 'staff users not allowed in this test'
+    assert not user.is_superuser, 'staff users not allowed in this test'
+    CourseAccessRole.objects.create(user_id=user_id, role=cs.COURSE_SUPPORT_ROLE_GLOBAL)
+    return user
 
 
 @pytest.fixture

--- a/tests/test_helpers/test_roles.py
+++ b/tests/test_helpers/test_roles.py
@@ -2042,6 +2042,19 @@ def test_get_accessible_tenant_ids_staff(base_data, user_id, expected):  # pylin
 
 
 @pytest.mark.django_db
+@pytest.mark.parametrize('roles_filter, expected_result, assertion_msg', [
+    (None, [1, 2, 3, 7, 8], 'when roles_filter is None, global role users must have access to all tenants'),
+    (cs.COURSE_ACCESS_ROLES_TENANT_OR_COURSE, [], 'access should be denied when the global role is\'t in roles_filter'),
+])
+def test_get_accessible_tenant_ids_global_role(
+    base_data, support_user, roles_filter, expected_result, assertion_msg,
+):  # pylint: disable=unused-argument
+    """Verify get_accessible_tenant_ids function for global roles users."""
+    result = get_accessible_tenant_ids(support_user, roles_filter=roles_filter)
+    assert result == expected_result, assertion_msg
+
+
+@pytest.mark.django_db
 @pytest.mark.parametrize('user_id, expected', [
     (3, [1]),
     (4, [1, 2, 7]),


### PR DESCRIPTION
fix: global roles do not have access to views

Scenario: the user has one role `support`

**Before the fix:** the user is not allowed to access the view

**After the fix:** the user is allowed to access the view

