### PR TITLE
fix: add usernames filter to enrollment API

### DIFF
--- a/futurex_openedx_extensions/dashboard/views.py
+++ b/futurex_openedx_extensions/dashboard/views.py
@@ -456,16 +456,22 @@ class LearnersEnrollmentView(ListAPIView, FXViewRoleInfoMixin):
         """Get the list of learners for a course"""
         course_ids = self.request.query_params.get('course_ids', '')
         user_ids = self.request.query_params.get('user_ids', '')
+        usernames = self.request.query_params.get('usernames', '')
         course_ids_list = [
             course.strip() for course in course_ids.split(',')
         ] if course_ids else None
         user_ids_list = [
             int(user.strip()) for user in user_ids.split(',') if user.strip().isdigit()
         ] if user_ids else None
+        usernames_list = [
+            username.strip() for username in usernames.split(',')
+        ] if usernames else None
+
         return get_learners_enrollments_queryset(
             fx_permission_info=self.request.fx_permission_info,
             user_ids=user_ids_list,
             course_ids=course_ids_list,
+            usernames=usernames_list,
             search_text=self.request.query_params.get('search_text'),
             include_staff=self.request.query_params.get('include_staff', '0') == '1',
         )

--- a/tests/test_dashboard/test_views.py
+++ b/tests/test_dashboard/test_views.py
@@ -813,6 +813,20 @@ class TestLearnersEnrollmentView(BaseTestViewMixin):
         self.assertEqual(response.data['results'][0]['user_id'], user_id)
         self.assertEqual(response.data['results'][0]['course_id'], course_id)
 
+    def test_success_for_user_ids_and_usernames(self):
+        """Verify that the view returns the correct response"""
+        self.login_user(self.staff_user)
+        response = self.client.get(self.url, data={
+            'user_ids': 15,
+            'usernames': 'user21, user15',
+        })
+        self.assertEqual(response.status_code, http_status.HTTP_200_OK)
+        self.assertEqual(response.data['count'], 6)
+        self.assertEqual(
+            set(user_data['user_id'] for user_data in response.data['results']),
+            {15, 21}
+        )
+
 
 class MockClickhouseQuery:
     """Mock ClickhouseQuery"""


### PR DESCRIPTION
Allow user to filter enrollments suing both user_ids and usernames.

GET /api/fx/learners/v1/enrollments/?user_ids=1,2&usernames=user1,user4 -> It will filter on users 1, 2, and 4
