### PR TITLE
feat: select the correct version according to edx-platform release-line

### DIFF
--- a/futurex_openedx_extensions/__init__.py
+++ b/futurex_openedx_extensions/__init__.py
@@ -1,3 +1,3 @@
 """One-line description for README and other doc files."""
 
-__version__ = '0.9.18'
+__version__ = '0.9.19'

--- a/futurex_openedx_extensions/upgrade/utils.py
+++ b/futurex_openedx_extensions/upgrade/utils.py
@@ -3,29 +3,31 @@ from __future__ import annotations
 
 import logging
 
-from django.conf import settings
+from openedx.core.release import RELEASE_LINE
 
 log = logging.getLogger(__name__)
 
 FX_EDX_PLATFORM_VERSION_PALM = 'palm'
 FX_EDX_PLATFORM_VERSION_REDWOOD = 'redwood'
 
-FX_DASHBOARD_DEFAULT_EDX_PLATFORM_VERSION = FX_EDX_PLATFORM_VERSION_PALM
 FX_DASHBOARD_SUPPORTED_EDX_PLATFORM_VERSION = [FX_EDX_PLATFORM_VERSION_PALM, FX_EDX_PLATFORM_VERSION_REDWOOD]
 
 
-def get_default_version() -> str:
-    """Get the default version of the edx-platform."""
-    return FX_DASHBOARD_DEFAULT_EDX_PLATFORM_VERSION
+def get_edx_platform_release() -> str:
+    """Get the edx-platform release."""
+    return RELEASE_LINE
 
 
 def get_current_version() -> str:
     """Get the current version of the edx-platform."""
-    default = get_default_version()
-    result = getattr(settings, 'FX_EDX_PLATFORM_VERSION', default) or default
+    result = get_edx_platform_release()
     if result not in FX_DASHBOARD_SUPPORTED_EDX_PLATFORM_VERSION:
+        if result < FX_EDX_PLATFORM_VERSION_PALM and result != 'master':
+            default = FX_EDX_PLATFORM_VERSION_PALM
+        else:
+            default = FX_EDX_PLATFORM_VERSION_REDWOOD
         log.error(
-            'FX_EDX_PLATFORM_VERSION was set to (%s) which is not a supported version. '
+            'edx-platform release line is (%s) which is not a supported version. '
             'Defaulting to (%s).', result, default,
         )
         result = default

--- a/test_settings_palm.py
+++ b/test_settings_palm.py
@@ -1,8 +1,9 @@
 """Test settings for edx-platform-palm"""
+from openedx.core import release
+
 from test_utils.test_settings_common import *
 
-# edx-platform version
-FX_EDX_PLATFORM_VERSION = 'palm'
+release.RELEASE_LINE = 'palm'
 
 # eox-tenant settings
 EOX_TENANT_USERS_BACKEND = 'eox_tenant.edxapp_wrapper.backends.users_l_v1'

--- a/test_settings_redwood.py
+++ b/test_settings_redwood.py
@@ -1,8 +1,9 @@
 """Test settings for edx-platform-palm"""
+from openedx.core import release
+
 from test_utils.test_settings_common import *
 
-# edx-platform version
-FX_EDX_PLATFORM_VERSION = 'redwood'
+release.RELEASE_LINE = 'redwood'
 
 # eox-tenant settings
 EOX_TENANT_USERS_BACKEND = 'eox_tenant.edxapp_wrapper.backends.users_p_v1'

--- a/test_utils/edx_platform_mocks_shared/openedx/core/release.py
+++ b/test_utils/edx_platform_mocks_shared/openedx/core/release.py
@@ -1,0 +1,2 @@
+"""edx-platform Mocks"""
+RELEASE_LINE = 'dummy-must-be-set-in-test-settings'

--- a/tests/test_upgrade/test_utils.py
+++ b/tests/test_upgrade/test_utils.py
@@ -2,63 +2,30 @@
 from unittest.mock import patch
 
 import pytest
-from django.conf import settings
-from django.test import override_settings
 
 from futurex_openedx_extensions.upgrade import utils
 
 
-def test_default_version_and_supported_versions():
-    """Verify versions definitions"""
-    assert isinstance(utils.FX_DASHBOARD_SUPPORTED_EDX_PLATFORM_VERSION, list)
-    assert utils.FX_DASHBOARD_SUPPORTED_EDX_PLATFORM_VERSION
-    assert isinstance(utils.FX_DASHBOARD_DEFAULT_EDX_PLATFORM_VERSION, str) and len(
-        utils.FX_DASHBOARD_DEFAULT_EDX_PLATFORM_VERSION
-    ) > 2
-    assert all(
-        isinstance(version, str) and len(version) > 2 for version in utils.FX_DASHBOARD_SUPPORTED_EDX_PLATFORM_VERSION
-    )
+def test_get_edx_platform_release():
+    """Verify that the release line is returned"""
+    with patch('futurex_openedx_extensions.upgrade.utils.RELEASE_LINE', 'testing-release'):
+        assert utils.get_edx_platform_release() == 'testing-release'
 
 
-def test_default_version_must_be_in_supported_versions():
-    """Test that the default version is in the supported versions"""
-    assert utils.FX_DASHBOARD_DEFAULT_EDX_PLATFORM_VERSION in utils.FX_DASHBOARD_SUPPORTED_EDX_PLATFORM_VERSION
-
-
-@patch('futurex_openedx_extensions.upgrade.utils.FX_DASHBOARD_DEFAULT_EDX_PLATFORM_VERSION', 'lolipop')
-def test_get_default_version():
-    """Verify that the default version is returned"""
-    assert utils.get_default_version() == 'lolipop'
-
-
-@pytest.mark.parametrize('in_settings, test_in_log, expected_result', [
-    ({'FX_EDX_PLATFORM_VERSION': None}, None, 'lolipop'),
-    ({'FX_EDX_PLATFORM_VERSION': ''}, None, 'lolipop'),
-    ({'FX_EDX_PLATFORM_VERSION': 'lolipop'}, None, 'lolipop'),
-    ({'FX_EDX_PLATFORM_VERSION': 'candy'}, None, 'candy'),
-    ({'FX_EDX_PLATFORM_VERSION': 'unsupported'}, 'unsupported', 'lolipop'),
+@pytest.mark.parametrize('release_line, expected_result, log_message', [
+    ('palm', 'palm', False),
+    ('redwood', 'redwood', False),
+    ('master', 'redwood', True),
+    ('juniper', 'palm', True),
+    ('sumac', 'redwood', True),
 ])
-@patch('futurex_openedx_extensions.upgrade.utils.FX_DASHBOARD_DEFAULT_EDX_PLATFORM_VERSION', 'lolipop')
-@patch('futurex_openedx_extensions.upgrade.utils.FX_DASHBOARD_SUPPORTED_EDX_PLATFORM_VERSION', ['lolipop', 'candy'])
-def test_get_current_version(in_settings, test_in_log, expected_result, caplog):
-    """Verify that the current version is returned"""
-    assert hasattr(settings, 'FX_EDX_PLATFORM_VERSION')
-
-    with override_settings(**in_settings):
+def test_get_current_version(release_line, expected_result, log_message, caplog):
+    """Verify that the current version is returned and logs are correct"""
+    with patch('futurex_openedx_extensions.upgrade.utils.get_edx_platform_release', return_value=release_line):
         assert utils.get_current_version() == expected_result
-    if test_in_log:
-        assert f'FX_EDX_PLATFORM_VERSION was set to ({test_in_log}) which is not a supported version. ' \
+
+    if log_message:
+        assert f'edx-platform release line is ({release_line}) which is not a supported version. ' \
                f'Defaulting to ({expected_result}).' in caplog.text
     else:
-        assert 'FX_EDX_PLATFORM_VERSION was set to' not in caplog.text
-
-
-@patch('futurex_openedx_extensions.upgrade.utils.FX_DASHBOARD_DEFAULT_EDX_PLATFORM_VERSION', 'lolipop')
-@patch('futurex_openedx_extensions.upgrade.utils.FX_DASHBOARD_SUPPORTED_EDX_PLATFORM_VERSION', ['lolipop', 'candy'])
-def test_get_current_version_missing_settings():
-    """Verify that the current version is returned from the default when the settings are missing"""
-    assert hasattr(settings, 'FX_EDX_PLATFORM_VERSION')
-    del settings.FX_EDX_PLATFORM_VERSION
-    assert not hasattr(settings, 'FX_EDX_PLATFORM_VERSION')
-
-    assert utils.get_current_version() == 'lolipop'
+        assert 'edx-platform release line is (' not in caplog.text


### PR DESCRIPTION
feat: select the correct version according to edx-platform release-line

* `palm` release will use `palm`
* releases before `palm` will use `palm`
* `redwood` release will use `redwood`
* releases after `redwood` (including `master`) will use `redwood`
