### PR TITLE
feat: add unique_leanrers statistics

### DIFF
--- a/tests/base_test_data.py
+++ b/tests/base_test_data.py
@@ -359,5 +359,6 @@ expected_statistics = {
     'total_hidden_courses_count': 0,
     'total_learners_count': 69,
     'total_learning_hours_count': 640,
+    'total_unique_learners': 37,
     'limited_access': False,
 }

--- a/tests/test_dashboard/test_views.py
+++ b/tests/test_dashboard/test_views.py
@@ -88,7 +88,7 @@ class TestTotalCountsView(BaseTestViewMixin):
         """Test get method"""
         self.login_user(self.staff_user)
         response = self.client.get(
-            self.url + '?stats=certificates,courses,hidden_courses,learners,enrollments,learning_hours'
+            self.url + '?stats=certificates,courses,hidden_courses,learners,enrollments,learning_hours,unique_learners'
         )
         self.assertTrue(isinstance(response, JsonResponse))
         self.assertEqual(response.status_code, http_status.HTTP_200_OK)


### PR DESCRIPTION
feat: add `unique_leanrers` statistics

```
GET api/fx/statistics/v1/total_counts/?stats=unique_leanrers
```

Unlike `stats=leanrers`; this will not recalculate the same learner having a record in multiple tenants

**Front-end Note**
This new stat is not useful for now because all the dashboard views are single-tenant views. This will be useful for the data-team; and will be useful in the future when we implement the Staff-View with multi-tenants