### PR TITLE
refactor: enhance a few tests to use base_data fixture

### DIFF
--- a/tests/test_helpers/test_export_csv.py
+++ b/tests/test_helpers/test_export_csv.py
@@ -9,7 +9,6 @@ from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.core.files.storage import default_storage
 from django.test import override_settings
-from eox_tenant.models import TenantConfig
 from storages.backends.s3boto3 import S3Boto3Storage
 
 from futurex_openedx_extensions.helpers.exceptions import FXCodedException
@@ -32,22 +31,13 @@ _FILENAME = 'test.csv'
 
 
 @pytest.fixture
-def user(db):  # pylint: disable=unused-argument
-    return get_user_model().objects.create_user(username='testuser', password='password')
-
-
-@pytest.fixture
-def tenant(db):  # pylint: disable=unused-argument
-    return TenantConfig.objects.create(external_key='test')
-
-
-@pytest.fixture
-def fx_task(db, user, tenant):  # pylint: disable=unused-argument,redefined-outer-name
+def fx_task():
+    """Fixture for DataExportTask."""
     return DataExportTask.objects.create(
         filename=_FILENAME,
         view_name='fake',
-        user=user,
-        tenant_id=tenant.id
+        user_id=30,
+        tenant_id=1,
     )
 
 
@@ -67,9 +57,10 @@ def test_export_data_to_csv_invalid_user(
     assert str(exc_info.value) == f'CSV Export: Invalid user id: {user_id}'
 
 
-def test_get_user_valid_id(user):  # pylint: disable=redefined-outer-name
+@pytest.mark.django_db
+def test_get_user_valid_id():
     """Test _get_user with a valid user_id."""
-    assert _get_user(user.id) == user
+    assert _get_user(30) == get_user_model().objects.get(id=30)
 
 
 def test_get_view_class_instance():
@@ -91,9 +82,11 @@ def test_export_data_to_csv_invalid_path(path, base_data):  # pylint: disable=un
     assert str(exc_info.value) == f'CSV Export: Missing required params "path" {path}'
 
 
+@pytest.mark.django_db
 @override_settings(ALLOWED_HOSTS=['test-url.somthing'])
-def test_get_mocked_request(user):  # pylint: disable=redefined-outer-name
+def test_get_mocked_request(base_data):  # pylint: disable=unused-argument
     """Test _get_mocked_request creates a mocked request properly."""
+    user = get_user_model().objects.get(id=30)
     fx_info = {'role': 'admin', 'user': user}
     url = 'http://test-url.somthing/?test=123'
     request = _get_mocked_request(url, fx_info)
@@ -102,9 +95,10 @@ def test_get_mocked_request(user):  # pylint: disable=redefined-outer-name
     assert request.fx_permission_info == fx_info
 
 
-def test_get_mocked_request_invalid_url(user):  # pylint: disable=redefined-outer-name
+@pytest.mark.django_db
+def test_get_mocked_request_invalid_url(base_data):  # pylint: disable=unused-argument
     """Test _get_mocked_request creates a mocked request properly."""
-    fx_info = {'role': 'admin', 'user': user}
+    fx_info = {'role': 'admin', 'user': get_user_model().objects.get(id=30)}
     url = '/test-url/?test=123'
     with pytest.raises(FXCodedException) as exc_info:
         _get_mocked_request(url, fx_info)
@@ -143,12 +137,13 @@ def test_get_response_data_failure(
     assert str(exc_info.value) == exception_msg
 
 
+@pytest.mark.django_db
 @override_settings(ALLOWED_HOSTS=['example.com'])
 @patch('futurex_openedx_extensions.helpers.export_csv._get_response_data')
 def test_paginated_response_generator(mock_get_response_data):
     """Test _paginated_response_generator"""
     url = 'http://example.com/api/data'
-    fx_info = {'role': 'admin', 'user': user}
+    fx_info = {'role': 'admin', 'user': get_user_model().objects.get(id=30)}
     page_size = 2
     view_data = {'url': f'{url}?test=value&page_size={page_size}'}
     mocked_response_1 = MagicMock()
@@ -184,11 +179,14 @@ def test_paginated_response_generator(mock_get_response_data):
     assert view_instance.call_count == 2
 
 
+@pytest.mark.django_db
 @override_settings(ALLOWED_HOSTS=['example.com'])
 @patch('futurex_openedx_extensions.helpers.export_csv._get_response_data')
-def test_paginated_response_generator_for_empty_response_data(mock_get_response_data):
+def test_paginated_response_generator_for_empty_response_data(
+    mock_get_response_data, base_data,
+):  # pylint: disable=unused-argument
     """Test _paginated_response_generator for empty response when there are no records"""
-    fx_info = {'role': 'admin', 'user': user}
+    fx_info = {'role': 'admin', 'user': get_user_model().objects.get(id=30)}
     view_data = {'url': 'http://example.com/api/data?test=value&page_size=2'}
     mocked_response = MagicMock()
     mocked_response.status_code = 200
@@ -205,10 +203,11 @@ def test_paginated_response_generator_for_empty_response_data(mock_get_response_
     view_instance.assert_called_once()
 
 
-def test_get_storage_dir(tenant):  # pylint: disable=redefined-outer-name
+def test_get_storage_dir():
     """Return storgae dir"""
-    expected = os.path.join(settings.FX_DASHBOARD_STORAGE_DIR, f'{str(tenant.id)}/exported_files')
-    result = _get_storage_dir(str(tenant.id))
+    tenant_id = 1
+    expected = os.path.join(settings.FX_DASHBOARD_STORAGE_DIR, f'{str(tenant_id)}/exported_files')
+    result = _get_storage_dir(str(tenant_id))
     assert result == expected
 
 
@@ -262,9 +261,10 @@ def test_upload_file_to_storage_set_private(mock_get_storage_dir, mock_storage):
 @patch('futurex_openedx_extensions.helpers.export_csv._paginated_response_generator')
 @patch('futurex_openedx_extensions.helpers.models.DataExportTask.get_task')
 def test_generate_csv_with_tracked_progress(
-    mock_get_task, mock_generator, tenant, base_data,
-):  # pylint: disable=redefined-outer-name, unused-argument
+    mock_get_task, mock_generator, base_data,
+):  # pylint: disable=unused-argument
     """Test _generate_csv_with_tracked_progress."""
+    tenant = MagicMock(id=1)
     task = MagicMock()
     task.tenant = tenant
     task.status = DataExportTask.STATUS_PROCESSING
@@ -272,7 +272,7 @@ def test_generate_csv_with_tracked_progress(
 
     storage_dir = f'{settings.FX_DASHBOARD_STORAGE_DIR}/{str(tenant.id)}/exported_files'
     fake_storage_path = f'{storage_dir}/{_FILENAME}'
-    fx_permission_info = {'user': user, 'role': 'admin'}
+    fx_permission_info = {'user': get_user_model().objects.get(id=30), 'role': 'admin'}
     view_data = {
         'page_size': 2,
         'url': 'http://example.com',
@@ -312,7 +312,7 @@ def test_generate_csv_with_tracked_progress_for_exception(
 ):  # pylint: disable=unused-argument
     """Test _generate_csv_with_tracked_progress for exception."""
     task = MagicMock()
-    fx_permission_info = {'user': user, 'role': 'admin'}
+    fx_permission_info = {'user': get_user_model().objects.get(id=30), 'role': 'admin'}
     view_data = {
         'page_size': 2,
         'url': 'http://example.com',
@@ -333,9 +333,10 @@ def test_generate_csv_with_tracked_progress_for_exception(
 @patch('futurex_openedx_extensions.helpers.export_csv.os.remove')
 @patch('futurex_openedx_extensions.helpers.models.DataExportTask.get_task')
 def test_generate_csv_with_tracked_progress_for_os_removal_exception(
-    mock_get_task, mock_os_remove, mock_generator, mock_file_upload, tenant, base_data,
-):  # pylint: disable=redefined-outer-name, unused-argument, too-many-arguments
+    mock_get_task, mock_os_remove, mock_generator, mock_file_upload, base_data,
+):  # pylint: disable=unused-argument
     """Test _generate_csv_with_tracked_progress for os exception"""
+    tenant = MagicMock(id=1)
     task = MagicMock()
     task.id = 99
     task.tenant_id = tenant.id
@@ -364,12 +365,13 @@ def test_generate_csv_with_tracked_progress_for_os_removal_exception(
 @pytest.mark.django_db
 @patch('futurex_openedx_extensions.helpers.export_csv._paginated_response_generator')
 def test_generate_csv_with_tracked_progress_for_empty_records(
-    mock_generator, fx_task, tenant, base_data,
+    mock_generator, fx_task, base_data,
 ):  # pylint: disable=redefined-outer-name, unused-argument
     """_generate_csv_with_tracked_progress for empty records"""
+    tenant = MagicMock(id=1)
     storage_dir = f'{settings.FX_DASHBOARD_STORAGE_DIR}/{str(tenant.id)}/exported_files'
     fake_storage_path = f'{storage_dir}/{_FILENAME}'
-    fx_permission_info = {'user': user, 'role': 'admin'}
+    fx_permission_info = {'user': get_user_model().objects.get(id=30), 'role': 'admin'}
     view_data = {
         'page_size': 2,
         'url': 'http://example.com',
@@ -389,12 +391,14 @@ def test_generate_csv_with_tracked_progress_for_empty_records(
     os.rmdir(settings.FX_DASHBOARD_STORAGE_DIR)
 
 
+@pytest.mark.django_db
 @patch('futurex_openedx_extensions.helpers.export_csv._get_view_class_instance')
 @patch('futurex_openedx_extensions.helpers.export_csv._generate_csv_with_tracked_progress')
 def test_export_data_to_csv(
-    mock_generate_csv, mock_get_view, fx_task, user
-):  # pylint: disable=redefined-outer-name
+    mock_generate_csv, mock_get_view, fx_task, base_data,
+):  # pylint: disable=redefined-outer-name, unused-argument
     """Test _export_data_to_csv"""
+    user = get_user_model().objects.get(id=30)
     mock_view_instance = MagicMock()
     mock_view_instance.view_class.pagination_class.max_page_size = 50
     mock_get_view.return_value = mock_view_instance
@@ -419,12 +423,14 @@ def test_export_data_to_csv(
     mock_get_view.assert_called_once_with(view_data['path'])
 
 
+@pytest.mark.django_db
 @patch('futurex_openedx_extensions.helpers.export_csv._get_view_class_instance')
 @patch('futurex_openedx_extensions.helpers.export_csv._generate_csv_with_tracked_progress')
 def test_export_data_to_csv_for_default_page_size(
-    mock_generate_csv, mock_get_view, fx_task, user
-):  # pylint: disable=redefined-outer-name
+    mock_generate_csv, mock_get_view, fx_task, base_data,
+):  # pylint: disable=redefined-outer-name, unused-argument
     """Test _export_data_to_csv"""
+    user = get_user_model().objects.get(id=30)
     fake_storage_path = f'{settings.FX_DASHBOARD_STORAGE_DIR}/{_FILENAME}'
     mocked_view_instance = MagicMock()
     mocked_view_instance.view_class.pagination_class.max_page_size = None
@@ -443,12 +449,14 @@ def test_export_data_to_csv_for_default_page_size(
     assert view_data['page_size'] == 100
 
 
+@pytest.mark.django_db
 @patch('futurex_openedx_extensions.helpers.export_csv._get_view_class_instance')
 @patch('futurex_openedx_extensions.helpers.export_csv._generate_csv_with_tracked_progress')
 def test_export_data_to_csv_for_missing_pagination_class(
-    mock_generate_csv, mock_get_view, fx_task, user
-):  # pylint: disable=redefined-outer-name
+    mock_generate_csv, mock_get_view, fx_task, base_data,
+):  # pylint: disable=redefined-outer-name, unused-argument
     """Test _export_data_to_csv"""
+    user = get_user_model().objects.get(id=30)
     fake_storage_path = f'{settings.FX_DASHBOARD_STORAGE_DIR}/{_FILENAME}'
     mocked_view_instance = MagicMock()
     mocked_view_instance.view_class.pagination_class = None
@@ -467,11 +475,12 @@ def test_export_data_to_csv_for_missing_pagination_class(
     assert view_data['page_size'] == 100
 
 
+@pytest.mark.django_db
 @patch('futurex_openedx_extensions.helpers.export_csv._get_view_class_instance')
 @patch('futurex_openedx_extensions.helpers.export_csv._generate_csv_with_tracked_progress')
 def test_export_data_to_csv_for_filename_extension(
-    mock_generate_csv, mock_get_view, fx_task, user
-):  # pylint: disable=redefined-outer-name
+    mock_generate_csv, mock_get_view, fx_task, base_data,
+):  # pylint: disable=redefined-outer-name, unused-argument
     """Test _export_data_to_csv"""
     filename = 'test'
     mock_view_instance = MagicMock()
@@ -480,7 +489,7 @@ def test_export_data_to_csv_for_filename_extension(
         'path': 'some/path',
         'query_params': {}
     }
-    fx_permission_info = {'user_id': user.id, 'role': 'admin'}
+    fx_permission_info = {'user_id': 30, 'role': 'admin'}
     mock_generate_csv.return_value = 'randome/path/test.csv'
     export_data_to_csv(fx_task.id, 'http://example.com/api', view_data, fx_permission_info, filename)
     mock_generate_csv.assert_called_once_with(
@@ -497,8 +506,8 @@ def test_export_data_to_csv_for_filename_extension(
 @patch('futurex_openedx_extensions.helpers.export_csv.default_storage')
 @patch('futurex_openedx_extensions.helpers.export_csv.generate_file_url')
 def test_get_exported_file_url(
-    mocked_generate_url, mock_storage, is_file_exist, is_task_completed, expected_return_value, user, base_data
-):  # pylint: disable=redefined-outer-name, too-many-arguments, unused-argument
+    mocked_generate_url, mock_storage, is_file_exist, is_task_completed, expected_return_value, base_data,
+):  # pylint: disable=too-many-arguments, unused-argument
     """Test get exported file URL"""
     mock_storage.exists.return_value = is_file_exist
     mock_storage.url.return_value = 'http://example.com/exported_file.csv' if is_file_exist else None
@@ -507,13 +516,14 @@ def test_get_exported_file_url(
         tenant_id=1,
         filename='exported_file.csv',
         status=DataExportTask.STATUS_COMPLETED if is_task_completed else DataExportTask.STATUS_IN_QUEUE,
-        user=user
+        user_id=30,
     )
     result = get_exported_file_url(task)
     assert result == expected_return_value
 
 
-def test_export_data_to_csv_for_url(fx_task):  # pylint: disable=redefined-outer-name
+@pytest.mark.django_db
+def test_export_data_to_csv_for_url(base_data, fx_task):  # pylint: disable=redefined-outer-name, unused-argument
     """Test _export_data_to_csv for URL"""
     url_with_query_str = 'http://example.com/api?key1=value1'
     with pytest.raises(FXCodedException) as exc_info:

--- a/tests/test_helpers/test_export_mixins.py
+++ b/tests/test_helpers/test_export_mixins.py
@@ -3,7 +3,6 @@ from unittest.mock import PropertyMock, patch
 
 import pytest
 from django.contrib.auth import get_user_model
-from eox_tenant.models import TenantConfig
 from rest_framework import status as http_status
 from rest_framework.test import APIRequestFactory
 
@@ -18,31 +17,22 @@ class TestView(ExportCSVMixin):
 
 
 @pytest.fixture
-def user(db):  # pylint: disable=unused-argument
-    return get_user_model().objects.create(username='testuser', password='password')
-
-
-@pytest.fixture
-def tenant(db):  # pylint: disable=unused-argument
-    return TenantConfig.objects.create(external_key='test')
-
-
-@pytest.fixture
-def export_csv_mixin(user, tenant):  # pylint: disable=redefined-outer-name
+def export_csv_mixin():
     """Create an instance of the ExportCSVMixin for testing."""
     view_instance = TestView()
     request = APIRequestFactory().get('/')
-    request.user = user
+    request.user = get_user_model().objects.get(username='user30')
     request.fx_permission_info = {
-        'user': user,
-        'view_allowed_tenant_ids_any_access': [tenant.id],
+        'user': request.user,
+        'view_allowed_tenant_ids_any_access': [1],
         'download_allowed': True,
     }
     view_instance.request = request
     return view_instance
 
 
-def test_export_filename(export_csv_mixin):  # pylint: disable=redefined-outer-name
+@pytest.mark.django_db
+def test_export_filename(base_data, export_csv_mixin):  # pylint: disable=redefined-outer-name, unused-argument
     """Test the export_filename property."""
     fake_time = '20241002_120000_123456'
     with patch('futurex_openedx_extensions.helpers.export_mixins.datetime') as mock_datetime_class:
@@ -52,27 +42,34 @@ def test_export_filename(export_csv_mixin):  # pylint: disable=redefined-outer-n
         assert filename == expected_filename
 
 
-def test_get_view_request_url(export_csv_mixin):  # pylint: disable=redefined-outer-name
+@pytest.mark.django_db
+def test_get_view_request_url(base_data, export_csv_mixin):  # pylint: disable=redefined-outer-name, unused-argument
     """Test the get_view_request_url method."""
     expected_url = 'http://testserver/'
     assert export_csv_mixin.get_view_request_url() == expected_url
 
 
-def test_get_filtered_query_params(export_csv_mixin):  # pylint: disable=redefined-outer-name
+@pytest.mark.django_db
+def test_get_filtered_query_params(
+    base_data, export_csv_mixin,
+):  # pylint: disable=redefined-outer-name, unused-argument
     """Test the get_filtered_query_params method."""
     export_csv_mixin.request.GET = {'download': 'csv', 'page_size': '10', 'page': '1', 'other_key': 'value'}
     expected_params = {'other_key': 'value'}
     assert export_csv_mixin.get_filtered_query_params() == expected_params
 
 
-def test_get_serialized_fx_permission_info(export_csv_mixin, user):  # pylint: disable=redefined-outer-name
+@pytest.mark.django_db
+def test_get_serialized_fx_permission_info(
+    base_data, export_csv_mixin,
+):  # pylint: disable=redefined-outer-name, unused-argument
     """Test get_serialized_fx_permission_info for user"""
     assert isinstance(export_csv_mixin.request.fx_permission_info.get('user'), get_user_model()) is True
     serialized_fx_info = export_csv_mixin.get_serialized_fx_permission_info()
     expected_serialized_fx_info = export_csv_mixin.request.fx_permission_info
     expected_serialized_fx_info.update({
         'user': None,
-        'user_id': user.id,
+        'user_id': 30,
     })
     assert serialized_fx_info == expected_serialized_fx_info
 
@@ -85,16 +82,15 @@ def test_generate_csv_url_response(
     mocked_get_query_params_func,
     mocked_get_view_request_url,
     mocked_export_data_to_csv_task,
+    base_data,
     export_csv_mixin,
-    user,
-    tenant,
-):  # pylint: disable=redefined-outer-name, too-many-arguments
+):  # pylint: disable=redefined-outer-name, unused-argument
     """Test the generate_csv_url_response method."""
     filename = 'mocked_file.csv'
     fake_url = 'http://example.com/view'
     export_csv_mixin.request.query_params = {'download': 'csv'}
     serialized_fx_permission_info = {
-        'user_id': user.id, 'user': None, 'view_allowed_tenant_ids_any_access': [tenant.id], 'download_allowed': True
+        'user_id': 30, 'user': None, 'view_allowed_tenant_ids_any_access': [1], 'download_allowed': True
     }
     fake_query_params = {}
     view_params = {'query_params': fake_query_params, 'kwargs': export_csv_mixin.kwargs, 'path': '/'}
@@ -115,52 +111,55 @@ def test_generate_csv_url_response(
 
 
 @pytest.mark.django_db
-def test_get_existing_incompleted_task_count(user, tenant, export_csv_mixin):  # pylint: disable=redefined-outer-name
+def test_get_existing_incompleted_task_count(
+    base_data, export_csv_mixin,
+):  # pylint: disable=redefined-outer-name, unused-argument
     """Test the incomplete task count logic."""
     filename = 'text.csv'
     related_id = 'test-id-1'
     current_view = 'test_export'
+    user_id = 30
 
     # Create tasks with different statuses
     # Add 2 valid tasks - should be counted
     DataExportTask.objects.create(
-        filename=filename, view_name=current_view, user=user, tenant=tenant,
+        filename=filename, view_name=current_view, user_id=user_id, tenant_id=1,
         related_id=related_id, progress=0.0, status=DataExportTask.STATUS_PROCESSING
     )
     DataExportTask.objects.create(
-        filename=filename, view_name=current_view, user=user, tenant=tenant,
+        filename=filename, view_name=current_view, user_id=user_id, tenant_id=1,
         related_id=related_id, progress=0.6, status=DataExportTask.STATUS_IN_QUEUE
     )
     # Add completed task - should not be counted
     DataExportTask.objects.create(
-        filename=filename, view_name=current_view, user=user, tenant=tenant,
+        filename=filename, view_name=current_view, user_id=user_id, tenant_id=1,
         related_id=related_id, progress=1.1, status=DataExportTask.STATUS_COMPLETED
     )
     assert export_csv_mixin.get_existing_incompleted_task_count() == 2
 
     # Add task from a different view - should not be counted
     DataExportTask.objects.create(
-        filename=filename, view_name='another view', user=user, tenant=tenant,
+        filename=filename, view_name='another view', user_id=user_id, tenant_id=1,
         related_id=related_id, progress=0.6, status=DataExportTask.STATUS_IN_QUEUE
     )
     assert export_csv_mixin.get_existing_incompleted_task_count() == 2
 
     # Add another valid task - should be counted
     DataExportTask.objects.create(
-        filename=filename, view_name=current_view, user=user, tenant=tenant,
+        filename=filename, view_name=current_view, user_id=user_id, tenant_id=1,
         related_id=related_id, progress=0.6, status=DataExportTask.STATUS_IN_QUEUE
     )
     assert export_csv_mixin.get_existing_incompleted_task_count() == 3
 
     # Add failed task - should not be counted
     DataExportTask.objects.create(
-        filename=filename, view_name=current_view, user=user, tenant=tenant,
+        filename=filename, view_name=current_view, user_id=user_id, tenant_id=1,
         related_id=related_id, progress=0.5, error_message='some error', status=DataExportTask.STATUS_FAILED
     )
     # Add task from another user - should not be counted
-    another_user = get_user_model().objects.get(id=1)
+    another_user = user_id + 1
     DataExportTask.objects.create(
-        filename=filename, view_name=current_view, user=another_user, tenant=tenant,
+        filename=filename, view_name=current_view, user_id=another_user, tenant_id=1,
         related_id=related_id, progress=0.5, error_message='some error', status=DataExportTask.STATUS_FAILED
     )
     # count of incomplete tasks should remain same i.e 3
@@ -226,22 +225,26 @@ def test_list_with_csv_download_for_different_http_statuses(
 
 
 @pytest.mark.django_db
-def test_list_with_csv_download_for_tasks_limit(export_csv_mixin, user, tenant):  # pylint: disable=redefined-outer-name
+def test_list_with_csv_download_for_tasks_limit(
+    base_data, export_csv_mixin,
+):  # pylint: disable=redefined-outer-name, unused-argument
     """Test the list method for tasks limit per user."""
     filename = 'text.csv'
     related_id = 'test-id-1'
     current_view = 'test_export'
+    user_id = 30
+
     export_csv_mixin.request.query_params = {'download': 'csv'}
     DataExportTask.objects.create(
-        filename=filename, view_name=current_view, user=user, tenant=tenant,
+        filename=filename, view_name=current_view, user_id=user_id, tenant_id=1,
         related_id=related_id, progress=0.0, status=DataExportTask.STATUS_PROCESSING
     )
     DataExportTask.objects.create(
-        filename=filename, view_name=current_view, user=user, tenant=tenant,
+        filename=filename, view_name=current_view, user_id=user_id, tenant_id=1,
         related_id=related_id, progress=0.6, status=DataExportTask.STATUS_IN_QUEUE
     )
     DataExportTask.objects.create(
-        filename=filename, view_name=current_view, user=user, tenant=tenant,
+        filename=filename, view_name=current_view, user_id=user_id, tenant_id=1,
         related_id=related_id, progress=0.6, status=DataExportTask.STATUS_IN_QUEUE
     )
     response = export_csv_mixin.list(export_csv_mixin.request)

--- a/tests/test_helpers/test_tasks.py
+++ b/tests/test_helpers/test_tasks.py
@@ -11,7 +11,7 @@ from futurex_openedx_extensions.helpers.tasks import export_data_to_csv_task
 
 @pytest.mark.django_db
 @patch('futurex_openedx_extensions.helpers.tasks.export_data_to_csv')
-def test_export_data_to_csv_task(mocked_export_data_to_csv):
+def test_export_data_to_csv_task(mocked_export_data_to_csv, base_data):  # pylint: disable=unused-argument
     """test export_data_to_csv_task functionality"""
     filename = 'test_file.csv'
     url = 'http://example.com/view'
@@ -21,7 +21,7 @@ def test_export_data_to_csv_task(mocked_export_data_to_csv):
         filename=filename,
         view_name='fake',
         user=user,
-        tenant_id=1
+        tenant_id=1,
     )
     fx_permission_info = {'user_id': user.id, 'role': 'admin'}
     assert fx_task.status == DataExportTask.STATUS_IN_QUEUE


### PR DESCRIPTION
refactor: enhance a few tests to use `base_data` fixture

we already have `base_data` ready to be used when sample data for tests is needed. This PR removes extra fixtures and replaces them with the sample data. It also removes the dependency of `tests/test_helpers/test_tasks.py` file on fixtures created in other files (every single test file should be able to run independently)