### PR TITLE
fix: allow dots in usernames in Roles APIs

### DIFF
--- a/futurex_openedx_extensions/dashboard/views.py
+++ b/futurex_openedx_extensions/dashboard/views.py
@@ -830,6 +830,7 @@ class UserRolesManagementView(FXViewRoleInfoMixin, viewsets.ModelViewSet):  # py
     fx_view_description = 'api/fx/roles/v1/user_roles/: user roles management APIs'
 
     lookup_field = 'username'
+    lookup_value_regex = '[^/]+'
     serializer_class = serializers.UserRolesSerializer
     pagination_class = DefaultPagination
 


### PR DESCRIPTION
## Description:

fix: allow dots in usernames in Roles APIs

### Related Issue:
* https://github.com/nelc/futurex-openedx-extensions/issues/207