### PR TITLE
feat: filter for hidden roles

### DIFF
--- a/futurex_openedx_extensions/dashboard/serializers.py
+++ b/futurex_openedx_extensions/dashboard/serializers.py
@@ -679,6 +679,7 @@ class UserRolesSerializer(LearnerBasicDetailsSerializer):
                 'only_course_ids'
             ].split(',') if query_params.get('only_course_ids') else [],
             'roles_filter': query_params.get('only_roles', '').split(',') if query_params.get('only_roles') else [],
+            'include_hidden_roles': query_params.get('include_hidden_roles', '0') == '1',
         }
 
         if query_params.get('active_users_filter') is not None:
@@ -751,6 +752,7 @@ class UserRolesSerializer(LearnerBasicDetailsSerializer):
             active_filter=self.query_params['active_filter'],
             course_ids_filter=self.query_params['course_ids_filter'],
             excluded_role_types=self.query_params['excluded_role_types'],
+            excluded_hidden_roles=not self.query_params['include_hidden_roles'],
         )
 
         for record in records or []:

--- a/futurex_openedx_extensions/dashboard/views.py
+++ b/futurex_openedx_extensions/dashboard/views.py
@@ -877,6 +877,7 @@ class UserRolesManagementView(FXViewRoleInfoMixin, viewsets.ModelViewSet):  # py
                     active_filter=dummy_serializers.query_params['active_filter'],
                     course_ids_filter=dummy_serializers.query_params['course_ids_filter'],
                     excluded_role_types=dummy_serializers.query_params['excluded_role_types'],
+                    excluded_hidden_roles=not dummy_serializers.query_params['include_hidden_roles'],
                 ).values('user_id').distinct().order_by()
             ).select_related('profile').order_by('id')
         except (ValueError, FXCodedException) as exc:

--- a/futurex_openedx_extensions/helpers/roles.py
+++ b/futurex_openedx_extensions/helpers/roles.py
@@ -613,6 +613,7 @@ def get_course_access_roles_queryset(  # pylint: disable=too-many-arguments, too
     active_filter: bool | None = None,
     course_ids_filter: list[str] | None = None,
     excluded_role_types: list[RoleType | str] | None = None,
+    excluded_hidden_roles: bool = False,
 ) -> QuerySet:
     """
     Get the course access roles queryset.
@@ -634,6 +635,8 @@ def get_course_access_roles_queryset(  # pylint: disable=too-many-arguments, too
     :type course_ids_filter: list
     :param excluded_role_types: The role types to exclude. None of empty list for no exclusion
     :type excluded_role_types: list of RoleType
+    :param excluded_hidden_roles: True to exclude hidden roles, False otherwise (default is True)
+    :type excluded_hidden_roles: bool
     :return: The roles for the users queryset
     :rtype: QuerySet
     """
@@ -688,6 +691,9 @@ def get_course_access_roles_queryset(  # pylint: disable=too-many-arguments, too
         roles_filter = cs.COURSE_ACCESS_ROLES_SUPPORTED_READ
     else:
         roles_filter = list(set(roles_filter).intersection(cs.COURSE_ACCESS_ROLES_SUPPORTED_READ))
+
+    if excluded_hidden_roles:
+        roles_filter = list(set(roles_filter) - set(cs.COURSE_ACCESS_ROLES_SUPPORTED_BUT_HIDDEN))
 
     allowed_roles = get_allowed_roles(roles_filter)
     queryset = queryset.filter(

--- a/tests/test_dashboard/test_serializers.py
+++ b/tests/test_dashboard/test_serializers.py
@@ -905,6 +905,7 @@ def test_user_roles_serializer_parse_query_params_defaults(
         'roles_filter': [],
         'active_filter': None,
         'excluded_role_types': [],
+        'include_hidden_roles': False,
     }
 
 
@@ -928,6 +929,7 @@ def test_user_roles_serializer_parse_query_params_values(excluded_role_types, re
             'only_roles': 'staff,instructor',
             'active_users_filter': '1',
             'excluded_role_types': excluded_role_types,
+            'include_hidden_roles': False,
         }),
         {
             'search_text': 'user99',
@@ -935,6 +937,7 @@ def test_user_roles_serializer_parse_query_params_values(excluded_role_types, re
             'roles_filter': ['staff', 'instructor'],
             'active_filter': True,
             'excluded_role_types': result_excluded_role_types,
+            'include_hidden_roles': False,
         },
         ignore_order=True,
     )

--- a/tests/test_helpers/test_roles.py
+++ b/tests/test_helpers/test_roles.py
@@ -1268,6 +1268,23 @@ def test_get_roles_for_users_queryset_exclude_bad_roles():
 
 
 @pytest.mark.django_db
+def test_get_roles_for_users_queryset_excluded_hidden_roles():
+    """Verify that get_roles_for_users_queryset does not include hidden roles when excluded_hidden_roles is True."""
+    user62 = get_user_model().objects.get(username='user62')
+    hidden_role = cs.COURSE_FX_API_ACCESS_ROLE_GLOBAL
+    assert hidden_role in cs.COURSE_ACCESS_ROLES_SUPPORTED_BUT_HIDDEN, 'bad roles used in test!'
+
+    CourseAccessRole.objects.create(user=user62, role=hidden_role)
+    test_orgs = get_all_orgs()
+
+    result = get_course_access_roles_queryset(orgs_filter=test_orgs, remove_redundant=True)
+    assert result.filter(user=user62).count() == 1
+
+    result = get_course_access_roles_queryset(orgs_filter=test_orgs, remove_redundant=True, excluded_hidden_roles=True)
+    assert result.filter(user=user62).count() == 0
+
+
+@pytest.mark.django_db
 def test_delete_course_access_roles(roles_authorize_caller, base_data):  # pylint: disable=unused-argument
     """Verify that delete_course_access_roles deletes the expected records."""
     user70 = get_user_model().objects.get(username='user70')


### PR DESCRIPTION
## Description:

Roles listing API returns annoying records of roles that should be hidden by default. Now the API hides these roles, and shows them if-and-only-if the query parameter `include_hidden_roles=1` is passed

Hidden roles:
* `fx_api_access`
* `fx_api_access_global`

### Related Issue: https://github.com/nelc/futurex-openedx-extensions/issues/200
