### PR TITLE
fix: relative_url_to_absolute_url not working properly

### DIFF
--- a/futurex_openedx_extensions/helpers/converters.py
+++ b/futurex_openedx_extensions/helpers/converters.py
@@ -30,8 +30,8 @@ def error_details_to_dictionary(reason: str, **details: Any) -> dict:
 
 def relative_url_to_absolute_url(relative_url: str, request: Any) -> str | None:
     """Convert a relative URL to an absolute URL"""
-    if request and hasattr(request, 'site') and request.site:
-        return str(urljoin(request.site.domain, relative_url))
+    if request and hasattr(request, 'scheme') and hasattr(request, 'site') and request.site:
+        return str(urljoin(f'{request.scheme}://{request.site.domain}', relative_url))
 
     return None
 

--- a/tests/test_dashboard/test_serializers.py
+++ b/tests/test_dashboard/test_serializers.py
@@ -572,7 +572,7 @@ def test_learner_details_extended_serializer(base_data):  # pylint: disable=unus
         bio='Test Bio',
         level_of_education='Test Level',
     )
-    request = Mock(site=Mock(domain='https://an-example.com'))
+    request = Mock(site=Mock(domain='an-example.com'), scheme='https')
     data = LearnerDetailsExtendedSerializer(queryset, many=True, context={'request': request}).data
     image_serialized = AccountLegacyProfileSerializer.get_profile_image(profile, queryset.first(), None)
     assert len(data) == 1
@@ -751,7 +751,7 @@ def test_learner_courses_details_serializer(base_data):  # pylint: disable=unuse
         'locked_count': 1,
     }
 
-    request = Mock(site=Mock(domain='https://test.com'))
+    request = Mock(site=Mock(domain='test.com'), scheme='https')
     with patch(
         'futurex_openedx_extensions.dashboard.serializers.get_course_blocks_completion_summary',
         return_value=completion_summary,

--- a/tests/test_helpers/test_certificates.py
+++ b/tests/test_helpers/test_certificates.py
@@ -25,7 +25,7 @@ def test_learner_courses_details_serializer_get_certificate_url(
     mock_get_certificates, certificates_url, expected_url, base_data,
 ):  # pylint: disable=unused-argument
     """Verify that the LearnerCoursesDetailsSerializer.get_certificate_url returns the correct data."""
-    request = Mock(site=Mock(domain='https://test.com'))
+    request = Mock(site=Mock(domain='test.com'), scheme='https')
     course = CourseOverview.objects.get(id='course-v1:ORG1+2+2')
     mock_get_certificates.return_value = {
         course.id: {

--- a/tests/test_helpers/test_converters.py
+++ b/tests/test_helpers/test_converters.py
@@ -68,8 +68,7 @@ def test_relative_url_to_absolute_url_no_site():
 
 def test_relative_url_to_absolute_url_with_site():
     """Verify that relative_url_to_absolute_url return the correct absolute URL."""
-    request = Mock()
-    request.site.domain = 'https://example-converter.com'
+    request = Mock(site=Mock(domain='example-converter.com'), scheme='https')
     assert converters.relative_url_to_absolute_url('/test9', request) == 'https://example-converter.com/test9'
 
 


### PR DESCRIPTION
## Description:

`relative_url_to_absolute_url` is not working properly. The related unit tests were mocking the `request.site.domain` in a wrong way. The domain does not contain the schema `http` or `https`, but the tests were assuming the schema already in the domain (my bad 🙄)

### Related Issue:  https://github.com/nelc/futurex-openedx-extensions/issues/187
