### PR TITLE
feat: use SSO term instead of Nafath

### DIFF
--- a/futurex_openedx_extensions/helpers/settings/common_production.py
+++ b/futurex_openedx_extensions/helpers/settings/common_production.py
@@ -59,18 +59,16 @@ def plugin_settings(settings: Any) -> None:
         },
     )
 
-    # Nafath Entry Id
-    settings.FX_NAFATH_ENTRY_ID = getattr(
+    # FX SSO Information
+    settings.FX_SSO_INFO = getattr(
         settings,
-        'FX_NAFATH_ENTRY_ID',
-        '',
-    )
-
-    # Nafath Social Auth Provider
-    settings.FX_NAFATH_AUTH_PROVIDER = getattr(
-        settings,
-        'FX_NAFATH_AUTH_PROVIDER',
-        'tpa-saml',
+        'FX_SSO_INFO',
+        {
+            'dummy_entity_id': {
+                'external_id_field': 'uid',
+                'external_id_extractor': None,  # should be a valid function or lambda
+            },
+        },
     )
 
     # Default Tenant site

--- a/requirements/test-constraints-redwood.txt
+++ b/requirements/test-constraints-redwood.txt
@@ -9,7 +9,9 @@ eox-tenant<v12.0.0
 edx-api-doc-tools==1.8.0
 edx-opaque-keys==2.9.0
 edx-lint==5.3.6
+django-config-models==2.7.0
 django-filter==24.2
 django-mysql==4.13.0
 jsonfield==3.1.0
 python-dateutil==2.9.0.post0
+social-auth-app-django==5.4.1

--- a/requirements/test-constraints-sumac.txt
+++ b/requirements/test-constraints-sumac.txt
@@ -9,7 +9,9 @@ eox-tenant<v13.0.0
 edx-api-doc-tools==2.0.0
 edx-opaque-keys==2.11.0
 edx-lint==5.4.0
+django-config-models==2.7.0
 django-filter==24.3
 django-mysql==4.14.0
 jsonfield==3.1.0
 python-dateutil==2.9.0.post0
+social-auth-app-django==5.4.1

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -18,8 +18,10 @@ eox-tenant
 edx-api-doc-tools
 edx-opaque-keys[django]
 djangorestframework
+django-config-models
 django-filter
 django-mysql
 django-simple-history
 jsonfield
 python-dateutil
+social-auth-app-django

--- a/test_utils/edx_platform_mocks_shared/fake_models/models.py
+++ b/test_utils/edx_platform_mocks_shared/fake_models/models.py
@@ -1,6 +1,7 @@
 """edx-platform models mocks for testing purposes."""
 import re
 
+from config_models.models import ConfigurationModel
 from django import forms
 from django.contrib.auth import get_user_model
 from django.contrib.sites.models import Site
@@ -322,24 +323,16 @@ class CourseAccessRoleForm(forms.ModelForm):
     role = forms.ChoiceField(choices=COURSE_ACCESS_ROLES)
 
 
-class SAMLProviderConfig(models.Model):
+class SAMLProviderConfig(ConfigurationModel):  # pylint: disable=feature-toggle-needs-doc
     """Mock"""
+    KEY_FIELDS = ('slug',)
+
     site = models.ForeignKey(Site, default=1, on_delete=models.CASCADE)
     name = models.CharField(max_length=255)
     enabled = models.BooleanField(default=False)
     entity_id = models.CharField(max_length=255)
+    slug = models.SlugField(max_length=30, db_index=True, default='default')
 
     class Meta:
         app_label = 'fake_models'
         db_table = 'third_party_auth_samlproviderconfig'
-
-
-class UserSocialAuth(models.Model):
-    """Mock"""
-    user = models.ForeignKey(get_user_model(), related_name='social_auth', on_delete=models.CASCADE)
-    provider = models.CharField(max_length=32)
-    extra_data = models.JSONField(default=dict, blank=True)
-
-    class Meta:
-        app_label = 'fake_models'
-        db_table = 'social_auth_usersocialauth'

--- a/test_utils/test_settings_common.py
+++ b/test_utils/test_settings_common.py
@@ -33,13 +33,13 @@ INSTALLED_APPS = (
     'django.contrib.messages',
     'django.contrib.sites',
     'django.contrib.sessions',
-    # 'futurex_openedx_extensions.dashboard',
     'futurex_openedx_extensions.helpers',
     'eox_tenant',
     'common',
     'fake_models',
     'openedx',
     'organizations',
+    'social_django',
 )
 
 USE_TZ = True
@@ -111,8 +111,18 @@ FX_DASHBOARD_STORAGE_DIR = 'test_dir'
 
 FX_DEFAULT_COURSE_EFFORT = 20
 
-FX_NAFATH_ENTRY_ID = 'abc.com'
-FX_NAFATH_AUTH_PROVIDER = 'dummy-provider'
+FX_SSO_INFO = {
+    'testing_entity_id1': {
+        'external_id_field': 'test_uid',
+        'external_id_extractor': lambda value: (
+            value[0] if isinstance(value, list) and len(value) == 1 else '' if isinstance(value, list) else value
+        )
+    },
+    'testing_entity_id2': {
+        'external_id_field': 'test_uid2',
+        'external_id_extractor': lambda value: value,
+    },
+}
 
 FX_DEFAULT_TENANT_SITE = 'default.example.com'
 FX_TENANTS_BASE_DOMAIN = 'local.overhang.io'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ from cms.djangoapps.course_creators.models import CourseCreator
 from common.djangoapps.student.models import CourseAccessRole, CourseEnrollment, UserSignupSource
 from custom_reg_form.models import ExtraInfo
 from django.contrib.auth import get_user_model
+from django.contrib.sites.models import Site
 from django.core.cache import cache
 from django.test import override_settings
 from django.utils import timezone
@@ -265,6 +266,13 @@ def base_data(django_db_setup, django_db_blocker):  # pylint: disable=unused-arg
                     if GeneratedCertificate.objects.count() % 2 == 0:
                         created_date -= datetime.timedelta(days=11)
 
+    def _create_sites():
+        """Create Sites."""
+        for _, tenant_config in _base_data['tenant_config'].items():
+            site_domain = tenant_config['lms_configs'].get('LMS_BASE')
+            if site_domain:
+                Site.objects.get_or_create(domain=site_domain)
+
     with django_db_blocker.unblock():
         _create_users()
         _create_tenants()
@@ -275,3 +283,4 @@ def base_data(django_db_setup, django_db_blocker):  # pylint: disable=unused-arg
         _create_ignored_course_access_roles()
         _create_course_enrollments()
         _create_certificates()
+        _create_sites()

--- a/tests/test_helpers/test_apps.py
+++ b/tests/test_helpers/test_apps.py
@@ -21,6 +21,12 @@ helpers_default_settings = [
         'quarter': 4,
         'year': 1,
     }),  # Max Period Chunks
+    ('FX_SSO_INFO', {
+        'dummy_entity_id': {
+            'external_id_field': 'uid',
+            'external_id_extractor': None,
+        },
+    }),
 ]
 
 


### PR DESCRIPTION
## Description:

Use SSO term instead of Nafath, and allow fetching user data when multiple SSO configs are available for the same site. The problem we have now is having multiple SSO entity IDs to be reported. Therefore, instead of `FX_NAFATH_ENTRY_ID` we'll use `FX_SSO_INFO` as a general term that contains a needed entity IDs along their basic information. The order of items in the `FX_SSO_INFO` settings will be respected when reporting the user's external ID. Only the first found ID will be reported

### Related Issue: https://github.com/nelc/futurex-openedx-extensions/issues/64