### PR TITLE
refactor: external_id_extractor

### DIFF
--- a/futurex_openedx_extensions/helpers/exceptions.py
+++ b/futurex_openedx_extensions/helpers/exceptions.py
@@ -56,6 +56,8 @@ class FXExceptionCodes(Enum):
 
     UPDATE_FAILED = 12001
 
+    BAD_CONFIGURATION_EXTERNAL_ID_EXTRACTOR = 13001
+
 
 class FXCodedException(Exception):
     """Exception with a code."""

--- a/futurex_openedx_extensions/helpers/extractors.py
+++ b/futurex_openedx_extensions/helpers/extractors.py
@@ -435,3 +435,21 @@ def get_valid_duration(
 
     return datetime.combine(date_from, datetime.min.time()) if date_from else None, \
         datetime.combine(date_to, datetime.max.time()) if date_to else None
+
+
+def external_id_extractor_value(value: Any) -> Any:
+    """external_id_extractor that returns the value as it is"""
+    return value
+
+
+def external_id_extractor_str_or_one_item_string_list(value: Any) -> Any:
+    """external_id_extractor that works with SSO providers similar to Nafath"""
+    if isinstance(value, list):
+        if len(value) == 1 and isinstance(value[0], (str, int)):
+            return str(value[0])
+        return ''
+
+    if isinstance(value, (str, int)):
+        return str(value)
+
+    return ''

--- a/futurex_openedx_extensions/helpers/settings/common_production.py
+++ b/futurex_openedx_extensions/helpers/settings/common_production.py
@@ -66,7 +66,7 @@ def plugin_settings(settings: Any) -> None:
         {
             'dummy_entity_id': {
                 'external_id_field': 'uid',
-                'external_id_extractor': None,  # should be a valid function or lambda
+                'external_id_extractor': 'path to function to be extracted using extractors.import_from_path'
             },
         },
     )

--- a/test_utils/test_settings_common.py
+++ b/test_utils/test_settings_common.py
@@ -114,13 +114,13 @@ FX_DEFAULT_COURSE_EFFORT = 20
 FX_SSO_INFO = {
     'testing_entity_id1': {
         'external_id_field': 'test_uid',
-        'external_id_extractor': lambda value: (
-            value[0] if isinstance(value, list) and len(value) == 1 else '' if isinstance(value, list) else value
-        )
+        'external_id_extractor':
+            'futurex_openedx_extensions.helpers.extractors::external_id_extractor_str_or_one_item_string_list',
     },
     'testing_entity_id2': {
         'external_id_field': 'test_uid2',
-        'external_id_extractor': lambda value: value,
+        'external_id_extractor':
+            'futurex_openedx_extensions.helpers.extractors::external_id_extractor_value',
     },
 }
 

--- a/tests/test_helpers/test_apps.py
+++ b/tests/test_helpers/test_apps.py
@@ -24,7 +24,7 @@ helpers_default_settings = [
     ('FX_SSO_INFO', {
         'dummy_entity_id': {
             'external_id_field': 'uid',
-            'external_id_extractor': None,
+            'external_id_extractor': 'path to function to be extracted using extractors.import_from_path'
         },
     }),
 ]

--- a/tests/test_helpers/test_extractors.py
+++ b/tests/test_helpers/test_extractors.py
@@ -12,6 +12,8 @@ from futurex_openedx_extensions.helpers.exceptions import FXCodedException
 from futurex_openedx_extensions.helpers.extractors import (
     DictHashcode,
     DictHashcodeSet,
+    external_id_extractor_str_or_one_item_string_list,
+    external_id_extractor_value,
     get_available_optional_field_tags,
     get_available_optional_field_tags_docs_table,
     get_course_id_from_uri,
@@ -574,3 +576,31 @@ def test_get_valid_duration_negative_max_chunks(date_from, date_to, expected_dat
             datetime.combine(expected_dates[0], datetime.min.time()) if expected_dates[0] else None,
             datetime.combine(expected_dates[1], datetime.max.time()) if expected_dates[1] else None,
         )
+
+
+@pytest.mark.parametrize('value, expected_result', [
+    ('test_string', 'test_string'),
+    (123, 123),
+    (['single_item'], ['single_item']),
+    ([], []),
+    ({'key': 'value'}, {'key': 'value'}),
+])
+def test_external_id_extractor_value(value, expected_result):
+    """Verify that external_id_extractor_value returns the expected value."""
+    assert external_id_extractor_value(value) == expected_result
+
+
+@pytest.mark.parametrize('value, expected_result', [
+    (123, '123'),
+    (['single_item'], 'single_item'),
+    ([123], '123'),
+    (['item1', 'item2'], ''),
+    ([123, 456], ''),
+    ([], ''),
+    ('normal_string', 'normal_string'),
+    ({'not': 'a string or a string list'}, ''),
+    (None, ''),
+])
+def test_external_id_extractor_str_or_one_item_string_list(value, expected_result):
+    """Verify that external_id_extractor_str_or_one_item_string_list returns the expected value."""
+    assert external_id_extractor_str_or_one_item_string_list(value) == expected_result


### PR DESCRIPTION
## Description:

Refactor the way `external_id_extractor` is processed. We need to keep the settings serializable to be easily configured in the `yml` files

### Related Issue: https://github.com/nelc/futurex-openedx-extensions/issues/64
