### PR TITLE
fix: draf config PUT missing up dictionaries

### DIFF
--- a/futurex_openedx_extensions/helpers/converters.py
+++ b/futurex_openedx_extensions/helpers/converters.py
@@ -236,7 +236,7 @@ def dict_to_hash(data_dict: dict) -> str:
     Generates a SHA-256 hash from a dictionary.
 
     :param data_dict: The dictionary to be hashed.
-    :return: A SHA-256 hash of the dictionary as a hexadecimal string.
+    :return: a SHA-256 hash of the dictionary as a hexadecimal string.
              Returns an empty string if the input dictionary is empty or None.
     """
     dict_str = json.dumps(data_dict, sort_keys=True, separators=(',', ':')) if data_dict else ''
@@ -270,3 +270,23 @@ def to_indian_numerals(text: str) -> str:
     :return: The text with Arabic numerals converted to Indian numerals.
     """
     return _text_translate(text, '0123456789', '٠١٢٣٤٥٦٧٨٩')
+
+
+def fill_deleted_keys_with_none(original: Dict[str, Any | None], updated: Dict[str, Any | None]) -> None:
+    """
+    Recursively adds missing keys from `original` into `updated` with value `None`.
+
+    :param original: The reference dictionary containing the expected structure.
+    :type original: Dict[str, Any | None]
+    :param updated: The dictionary to be updated in place. Keys from `updated` that are not in `original` will be
+        added with value `None`.
+    :type updated: Dict[str, Any | None]
+    """
+    if not isinstance(original, dict) or not isinstance(updated, dict):
+        return
+
+    for key in original:
+        if key not in updated:
+            updated[key] = None
+        elif isinstance(original[key], dict) and isinstance(updated[key], dict):
+            fill_deleted_keys_with_none(original[key], updated[key])

--- a/futurex_openedx_extensions/helpers/tenants.py
+++ b/futurex_openedx_extensions/helpers/tenants.py
@@ -15,6 +15,7 @@ from rest_framework.exceptions import PermissionDenied
 
 from futurex_openedx_extensions.helpers import constants as cs
 from futurex_openedx_extensions.helpers.caching import cache_dict, invalidate_cache
+from futurex_openedx_extensions.helpers.converters import fill_deleted_keys_with_none
 from futurex_openedx_extensions.helpers.exceptions import FXCodedException, FXExceptionCodes
 from futurex_openedx_extensions.helpers.extractors import get_first_not_empty_item
 from futurex_openedx_extensions.helpers.models import ConfigAccessControl
@@ -566,6 +567,8 @@ def update_draft_tenant_config(   # pylint: disable=too-many-arguments, unused-a
         Q(config_draft_exists=True, config_draft_value=current_value) |
         Q(config_draft_exists=False, root_key_exists=True, root_value=current_value)
     )
+
+    fill_deleted_keys_with_none(current_value, new_value)
 
     updated = queryset.filter(condition).update(
         lms_configs=apply_json_merge_for_update_draft_config(F('lms_configs'), key_path, new_value, reset)

--- a/tests/test_helpers/test_converters.py
+++ b/tests/test_helpers/test_converters.py
@@ -182,3 +182,44 @@ def test_path_to_json(path, value, expected_output):
 def test_to_indian_numerals(input_text, expected_output, test_case):
     """Verify that to_indian_numerals returns correct data"""
     assert converters.to_indian_numerals(input_text) == expected_output, f'Failed: {test_case}'
+
+
+@pytest.mark.parametrize(
+    'original, updated, expected, test_case',
+    [
+        (
+            {'a': 1, 'b': {'c': 2}},
+            {'a': 1},
+            {'a': 1, 'b': None},
+            'Nested key missing in updated'
+        ),
+        (
+            {'a': 1, 'b': {'c': 2, 'd': {'e': 3}}},
+            {'a': 1, 'b': {'c': 2}},
+            {'a': 1, 'b': {'c': 2, 'd': None}},
+            'Deeply nested key missing in updated'
+        ),
+        (
+            {'a': 1, 'b': {'c': 2}},
+            {'a': 1, 'b': {'c': 2, 'd': 3}},
+            {'a': 1, 'b': {'c': 2, 'd': 3}},
+            'Updated already has all keys'
+        ),
+        (
+            {'a': 1, 'b': {'c': 2}},
+            {},
+            {'a': None, 'b': None},
+            'Updated is an empty dictionary'
+        ),
+        (
+            {},
+            {'a': 1, 'b': {'c': 2}},
+            {'a': 1, 'b': {'c': 2}},
+            'Original is empty, no changes should happen'
+        ),
+    ]
+)
+def test_fill_deleted_keys_with_none(original, updated, expected, test_case):
+    """Verify fill_deleted_keys_with_none fills missing keys from original to updated with value None."""
+    converters.fill_deleted_keys_with_none(original, updated)
+    assert updated == expected, test_case


### PR DESCRIPTION
## Description:

Draf config PUT is updating dictionary items instead of replacing them. 

### Related Issue: https://github.com/nelc/futurex-openedx-extensions/issues/263
