### PR TITLE
fix: port number in site-domain should be ignored

### DIFF
--- a/futurex_openedx_extensions/helpers/tenants.py
+++ b/futurex_openedx_extensions/helpers/tenants.py
@@ -39,10 +39,14 @@ def get_excluded_tenant_ids() -> Dict[int, List[int]]:
         if tenant.routes_count > 1:
             reasons.append(FXExceptionCodes.TENANT_HAS_MORE_THAN_ONE_SITE.value)
 
-        if not tenant.lms_configs.get('LMS_BASE'):
+        lms_base = tenant.lms_configs.get('LMS_BASE')
+        if not lms_base:
             reasons.append(FXExceptionCodes.TENANT_HAS_NO_LMS_BASE.value)
-        if not reasons and tenant.lms_configs['LMS_BASE'] != tenant.route_domain:
-            reasons.append(FXExceptionCodes.TENANT_LMS_BASE_SITE_MISMATCH.value)
+
+        if lms_base and not reasons:
+            lms_base = lms_base.split(':')[-2] if ':' in lms_base else lms_base
+            if lms_base != tenant.route_domain:
+                reasons.append(FXExceptionCodes.TENANT_LMS_BASE_SITE_MISMATCH.value)
 
         if not tenant.lms_configs.get('IS_FX_DASHBOARD_ENABLED', True):
             reasons.append(FXExceptionCodes.TENANT_DASHBOARD_NOT_ENABLED.value)

--- a/tests/test_helpers/test_tenants.py
+++ b/tests/test_helpers/test_tenants.py
@@ -37,6 +37,20 @@ def test_get_excluded_tenant_ids(
 
 
 @pytest.mark.django_db
+def test_get_excluded_tenant_ids_port_number(
+    base_data, expected_exclusion,
+):  # pylint: disable=unused-argument, redefined-outer-name
+    """Verify get_excluded_tenant_ids function works correctly when the site-domain has a port number."""
+    for tenant_config in TenantConfig.objects.all():
+        lms_base = tenant_config.lms_configs.get('LMS_BASE')
+        if lms_base:
+            tenant_config.lms_configs['LMS_BASE'] = f'{lms_base}:1234'
+            tenant_config.save()
+
+    assert tenants.get_excluded_tenant_ids() == expected_exclusion
+
+
+@pytest.mark.django_db
 def test_get_excluded_tenant_ids_more_than_one_tenant(
     base_data, expected_exclusion,
 ):  # pylint: disable=unused-argument, redefined-outer-name


### PR DESCRIPTION
## Description:

Port number in site-domain should be ignored to align with `eox-tenant` logic

### Related Issue: https://github.com/nelc/futurex-openedx-extensions/issues/267
