### PR TITLE
chore: update tox.ini for failing tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -42,6 +42,9 @@ setenv =
     redwood: PYTEST_COV_CONFIG = {toxinidir}/.coveragerc-redwood
     sumac: DJANGO_SETTINGS_MODULE = test_settings_sumac
     sumac: PYTEST_COV_CONFIG = {toxinidir}/.coveragerc-sumac
+    redwood: PYTHONPATH = {toxinidir}/test_utils/edx_platform_mocks_shared:{toxinidir}/test_utils/edx_platform_mocks_redwood:{env:PYTHONPATH:}
+    sumac: PYTHONPATH = {toxinidir}/test_utils/edx_platform_mocks_shared:{toxinidir}/test_utils/edx_platform_mocks_sumac:{env:PYTHONPATH:}
+    PYTHONPATH = {toxinidir}/test_utils/edx_platform_mocks_shared:{env:PYTHONPATH:}
 deps =
     redwood: -c{toxinidir}/requirements/test-constraints-redwood.txt
     sumac: -c{toxinidir}/requirements/test-constraints-sumac.txt


### PR DESCRIPTION
Fix failing Github tests.

I found 2 options to fix it.

**Option1:**
- update pythonpath in setenv of tox
```
redwood: PYTHONPATH = {toxinidir}/test_utils/edx_platform_mocks_shared:{toxinidir}/test_utils/edx_platform_mocks_redwood:{env:PYTHONPATH:}

sumac: PYTHONPATH = {toxinidir}/test_utils/edx_platform_mocks_shared:{toxinidir}/test_utils/edx_platform_mocks_sumac:{env:PYTHONPATH:}

PYTHONPATH = {toxinidir}/test_utils/edx_platform_mocks_shared:{env:PYTHONPATH:}
```
**Option 2:**
- Packages are not recognised due to missing init files in folders. To fix this, we need to add __init__.py and update setup.py with following.
```
setup(
    name='edx_platform_mocks_shared',
    version='0.1.0',
    py_modules=["boto3", "celery", "bridgekeeper"], //individual python files not packages
    packages=find_packages() // it will get all packages that contains __init__.py so can be import later
)
```

Fixed issue with option1.