### PR TITLE
feat: add api to list courses feedbacks

### DIFF
--- a/futurex_openedx_extensions/dashboard/docs_src.py
+++ b/futurex_openedx_extensions/dashboard/docs_src.py
@@ -631,6 +631,63 @@ docs_src = {
         ),
     },
 
+    'CoursesFeedbackView.get': {
+        'summary': 'Get the list of feedback of courses in the tenants',
+        'description': 'Get the list of feedbacks for accessible courses.',
+        'parameters': [
+            common_parameters['tenant_ids'],
+            query_parameter(
+                'search_text',
+                str,
+                'A search text to filter the results by. The search text will be matched against the feedback comment.',
+            ),
+            query_parameter(
+                'course_ids',
+                str,
+                'A comma-separated list of course IDs to filter the results by. If not provided, the system will '
+                'assume all courses that are accessible to the caller.',
+            ),
+            query_parameter(
+                'rating_instructors',
+                str,
+                'A comma-separated list of integers (in range 1 to 5), e.g., `2,3`, to filter the results by.',
+            ),
+            query_parameter(
+                'rating_content',
+                str,
+                'A comma-separated list of integers (in range 1 to 5), e.g., `2,3`, to filter the results by.',
+            ),
+            openapi.Parameter(
+                'public_only',
+                ParameterLocation.QUERY,
+                required=False,
+                type=openapi.TYPE_INTEGER,
+                enum=[1, 0],
+                description=(
+                    'When set to `1`, returns only public feedbacks. Defaults to `0`. '
+                    'Any value other than `1` is treated as `0`.'
+                )
+            ),
+            openapi.Parameter(
+                'recommended_only',
+                ParameterLocation.QUERY,
+                required=False,
+                type=openapi.TYPE_INTEGER,
+                enum=[1, 0],
+                description=(
+                    'When set to `1`, returns only feedbacks where the user recommended the course. Defaults to `0`. '
+                    'Any value other than `1` is treated as `0`.'
+                )
+            ),
+            common_parameters['download'],
+        ],
+        'responses': responses(
+            overrides={
+                200: serializers.CoursesFeedbackSerializer(read_only=True, required=False),
+            },
+        ),
+    },
+
     'DataExportManagementView.list': {
         'summary': 'Get the list of data export tasks for the caller',
         'description': 'Get the list of data export tasks for the caller.',

--- a/futurex_openedx_extensions/dashboard/docs_src.py
+++ b/futurex_openedx_extensions/dashboard/docs_src.py
@@ -650,12 +650,12 @@ docs_src = {
             query_parameter(
                 'rating_instructors',
                 str,
-                'A comma-separated list of integers (in range 1 to 5), e.g., `2,3`, to filter the results by.',
+                'A comma-separated list of integers from 0 to 5 (inclusive), e.g., `2,3`, to filter the results by.',
             ),
             query_parameter(
                 'rating_content',
                 str,
-                'A comma-separated list of integers (in range 1 to 5), e.g., `2,3`, to filter the results by.',
+                'A comma-separated list of integers from 0 to 5 (inclusive), e.g., `2,3`, to filter the results by.',
             ),
             openapi.Parameter(
                 'public_only',
@@ -782,7 +782,7 @@ docs_src = {
         'summary': 'Get global rating statistics for the tenants',
         'description': 'Get global rating statistics for the tenants. The response will include the average rating and'
         ' the total number of ratings for the selected tenants, plus the number of ratings for each rating value from'
-        ' 1 to 5.\n'
+        ' 0 to 5 (inclusive).\n'
         '\n**Note:** the count includes only visible courses.\n'
         f'{repeated_descriptions["visible_course_definition"]}',
         'parameters': [

--- a/futurex_openedx_extensions/dashboard/urls.py
+++ b/futurex_openedx_extensions/dashboard/urls.py
@@ -26,6 +26,8 @@ urlpatterns = [
     re_path(r'^api/fx/accessible/v2/info/$', views.AccessibleTenantsInfoViewV2.as_view(), name='accessible-info-v2'),
     re_path(r'^api/fx/courses/v1/courses/$', views.CoursesView.as_view(), name='courses'),
     re_path(r'^api/fx/libraries/v1/libraries/$', views.LibraryView.as_view(), name='libraries'),
+    re_path(r'^api/fx/courses/v1/feedback/$', views.CoursesFeedbackView.as_view(), name='courses-feedback'),
+
     re_path(r'^api/fx/export/v1/', include(export_router.urls)),
     re_path(r'^api/fx/learners/v1/learners/$', views.LearnersView.as_view(), name='learners'),
     re_path(

--- a/futurex_openedx_extensions/dashboard/views.py
+++ b/futurex_openedx_extensions/dashboard/views.py
@@ -892,10 +892,10 @@ class CoursesFeedbackView(ExportCSVMixin, FXViewRoleInfoMixin, ListAPIView):
                 message=f"'{param_key}' must be a comma-separated list of valid integers."
             ) from exc
 
-        if any(r < 1 or r > 5 for r in ratings):
+        if any(r < 0 or r > 5 for r in ratings):
             raise FXCodedException(
                 code=FXExceptionCodes.INVALID_INPUT,
-                message=f"Each value in '{param_key}' must be between 1 and 5."
+                message=f"Each value in '{param_key}' must be between 0 and 5 (inclusive)."
             )
 
         return ratings
@@ -912,7 +912,7 @@ class CoursesFeedbackView(ExportCSVMixin, FXViewRoleInfoMixin, ListAPIView):
             course_ids=course_ids_list,
             public_only=self.request.query_params.get('public_only', '0') == '1',
             recommended_only=self.request.query_params.get('recommended_only', '0') == '1',
-            feedback_search=self.request.query_params.get('search_text'),
+            feedback_search=self.request.query_params.get('feedback_search'),
             rating_content_filter=self.validate_rating_list('rating_content'),
             rating_instructors_filter=self.validate_rating_list('rating_instructors')
         )

--- a/tests/test_dashboard/test_views.py
+++ b/tests/test_dashboard/test_views.py
@@ -794,11 +794,11 @@ class TestCoursesFeedbackView(BaseTestViewMixin):
         assert len(response.data['results']) == 1
         assert response.data['results'][0]['feedback'] == 'some comment 2'
 
-    def test_filter_by_search_text(self):
-        """Verify filtering by search_text returns matching feedback"""
+    def test_filter_by_feedback_search(self):
+        """Verify filtering by feedback_search returns matching feedback"""
         self.prepare_feedbacks()
         self.login_user(self.staff_user)
-        response = self.client.get(self.url + '?search_text=learner')
+        response = self.client.get(self.url + '?feedback_search=learner')
         self.assertEqual(response.status_code, http_status.HTTP_200_OK)
         assert len(response.data['results']) == 1
         assert 'learner' in response.data['results'][0]['feedback']
@@ -845,7 +845,12 @@ class TestCoursesFeedbackView(BaseTestViewMixin):
         (
             '3,6',
             http_status.HTTP_400_BAD_REQUEST,
-            "Each value in 'rating_content' must be between 1 and 5."
+            "Each value in 'rating_content' must be between 0 and 5 (inclusive)."
+        ),
+        (
+            '3,-1',
+            http_status.HTTP_400_BAD_REQUEST,
+            "Each value in 'rating_content' must be between 0 and 5 (inclusive)."
         ),
         (
             '3,2,invalid',

--- a/tests/test_dashboard/test_views.py
+++ b/tests/test_dashboard/test_views.py
@@ -22,6 +22,7 @@ from django.test import override_settings
 from django.urls import resolve, reverse
 from django.utils.functional import SimpleLazyObject
 from django.utils.timezone import now, timedelta
+from eox_nelp.course_experience.models import FeedbackCourse
 from eox_tenant.models import Route, TenantConfig
 from opaque_keys.edx.locator import CourseLocator, LibraryLocator
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
@@ -711,6 +712,159 @@ class TestCoursesView(BaseTestViewMixin):
         })
         self.assertEqual(response.status_code, http_status.HTTP_400_BAD_REQUEST)
         self.assertEqual(response.json()['errors']['tenant_id'][0], expected_error, f'Failed for usecase: {case}')
+
+
+@ddt.ddt
+@pytest.mark.usefixtures('base_data')
+class TestCoursesFeedbackView(BaseTestViewMixin):
+    """Tests for CoursesFeedbackView"""
+    VIEW_NAME = 'fx_dashboard:courses-feedback'
+
+    @staticmethod
+    def prepare_feedbacks() -> None:
+        """Create all components required for tests"""
+        FeedbackCourse.objects.create(
+            author=get_user_model().objects.get(id=3),
+            course_id=CourseOverview.objects.get(id='course-v1:Org1+1+1'),
+            rating_content=5,
+            feedback='some comment 1',
+            public=True,
+            rating_instructors=4,
+            recommended=True,
+        )
+        FeedbackCourse.objects.create(
+            author=get_user_model().objects.get(id=1),
+            course_id=CourseOverview.objects.get(id='course-v1:ORG1+2+2'),
+            rating_content=4,
+            feedback='some comment 2',
+            public=True,
+            rating_instructors=3,
+            recommended=True,
+        )
+        FeedbackCourse.objects.create(
+            author=get_user_model().objects.get(id=3),
+            course_id=CourseOverview.objects.get(id='course-v1:ORG1+4+4'),
+            rating_content=2,
+            feedback='some comment 3',
+            public=False,
+            rating_instructors=2,
+            recommended=True,
+        )
+        FeedbackCourse.objects.create(
+            author=get_user_model().objects.get(id=47),
+            course_id=CourseOverview.objects.get(id='course-v1:ORG8+1+1'),
+            rating_content=5,
+            feedback='some comment by learner',
+            public=True,
+            rating_instructors=1,
+            recommended=False,
+        )
+
+    def test_unauthorized(self):
+        """Verify that the view returns 403 when the user is not authenticated"""
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, http_status.HTTP_403_FORBIDDEN)
+
+    def test_success_no_filters(self):
+        """Verify that user can only view feedbacks of accessible courses"""
+        self.prepare_feedbacks()
+        self.login_user(self.staff_user)
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, http_status.HTTP_200_OK)
+        self.assertEqual(
+            len(response.data['results']),
+            4,
+            'Unexpected result, as global staff user should have access to all feedbacks'
+        )
+        self.login_user(23)
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, http_status.HTTP_200_OK)
+        self.assertEqual(
+            len(response.data['results']),
+            1,
+            'Unexpected result, user 23 has only access to org5 and org8 courses.'
+        )
+
+    def test_filter_by_course_ids(self):
+        """Verify filtering by course_ids returns only feedbacks for specified courses"""
+        self.prepare_feedbacks()
+        self.login_user(self.staff_user)
+        response = self.client.get(self.url + '?course_ids=course-v1%3AORG1%2B2%2B2')
+        self.assertEqual(response.status_code, http_status.HTTP_200_OK)
+        assert len(response.data['results']) == 1
+        assert response.data['results'][0]['feedback'] == 'some comment 2'
+
+    def test_filter_by_search_text(self):
+        """Verify filtering by search_text returns matching feedback"""
+        self.prepare_feedbacks()
+        self.login_user(self.staff_user)
+        response = self.client.get(self.url + '?search_text=learner')
+        self.assertEqual(response.status_code, http_status.HTTP_200_OK)
+        assert len(response.data['results']) == 1
+        assert 'learner' in response.data['results'][0]['feedback']
+
+    def test_filter_by_public_only(self):
+        """Verify filtering by public_only=1 returns only public feedbacks"""
+        self.prepare_feedbacks()
+        self.login_user(self.staff_user)
+        response = self.client.get(self.url + '?public_only=1')
+        self.assertEqual(response.status_code, http_status.HTTP_200_OK)
+        assert len(response.data['results']) == 3  # 1 feedback is public=False
+
+    def test_filter_by_recommended_only(self):
+        """Verify filtering by recommended_only=1 returns only recommended feedbacks"""
+        self.prepare_feedbacks()
+        self.login_user(self.staff_user)
+        response = self.client.get(self.url + '?recommended_only=1')
+        self.assertEqual(response.status_code, http_status.HTTP_200_OK)
+        assert len(response.data['results']) == 3  # 1 feedback is recommended=False
+
+    def test_filter_by_rating_content(self):
+        """Verify filtering by rating_content returns only matching ratings"""
+        self.prepare_feedbacks()
+        self.login_user(self.staff_user)
+        response = self.client.get(self.url + '?rating_content=5')
+        self.assertEqual(response.status_code, http_status.HTTP_200_OK)
+        assert len(response.data['results']) == 2
+
+    def test_filter_by_rating_instructors(self):
+        """Verify filtering by rating_instructors returns only matching instructor ratings"""
+        self.prepare_feedbacks()
+        self.login_user(self.staff_user)
+        response = self.client.get(self.url + '?rating_instructors=2')
+        self.assertEqual(response.status_code, http_status.HTTP_200_OK)
+        assert len(response.data['results']) == 1
+        assert response.data['results'][0]['rating_instructors'] == 2
+
+    @ddt.data(
+        (
+            '5,2',
+            http_status.HTTP_200_OK,
+            None
+        ),
+        (
+            '3,6',
+            http_status.HTTP_400_BAD_REQUEST,
+            "Each value in 'rating_content' must be between 1 and 5."
+        ),
+        (
+            '3,2,invalid',
+            http_status.HTTP_400_BAD_REQUEST,
+            "'rating_content' must be a comma-separated list of valid integers."
+        ),
+    )
+    @ddt.unpack
+    def test_rating_content_validation(self, query, expected_status, error_message):
+        """Test rating_content filter for validation logic"""
+        self.prepare_feedbacks()
+        self.login_user(self.staff_user)
+        response = self.client.get(f'{self.url}?rating_content={query}')
+        assert response.status_code == expected_status
+        if expected_status == http_status.HTTP_400_BAD_REQUEST:
+            assert response.json()['reason'] == error_message
+        else:
+            assert 'results' in response.data
+            assert len(response.data['results']) == 3
 
 
 @ddt.ddt


### PR DESCRIPTION
## Description:

Added new API

`GET api/fx/courses/v1/feedback/`

Sample Repsonse 200:
```
{
            "id": 2,
            "course_id": "course-v1:nelp+111+11",
            "course_name": "course 1 nelp",
            "author_username": "user1",
            "author_full_name": "user1",
            "author_altternative_full_name": "عالي",
            "author_email": "user1@exmaple.com",
            "rating_content": 2,
            "feedback": "another comment",
            "public": true,
            "rating_instructors": 4,
            "recommended": true
 }
```
### Related Issue:
