### PR TITLE
feat: system-staff users special access to tenant assets

### DIFF
--- a/futurex_openedx_extensions/dashboard/docs_src.py
+++ b/futurex_openedx_extensions/dashboard/docs_src.py
@@ -1953,7 +1953,7 @@ docs_src = {
         ),
     },
 
-    'CourseAssetsManagementView.create': {
+    'TenantAssetsManagementView.create': {
         'summary': 'Add new asset to the tenant',
         'description': 'Add new asset to the tenant. \n `Note:` If an asset with the same slug already exists, the '
         'existing record will be updated with the new file instead of creating a duplicate entry. The old file will '
@@ -1967,7 +1967,7 @@ docs_src = {
         ),
     },
 
-    'CourseAssetsManagementView.list': {
+    'TenantAssetsManagementView.list': {
         'summary': 'List all asset',
         'description': 'Retrieve a list of all assets. System admins can view all assets, while other users can only '
         'view assets associated with their accessible tenant. Use the Tenant ID filter to narrow down the results to a '

--- a/futurex_openedx_extensions/dashboard/docs_src.py
+++ b/futurex_openedx_extensions/dashboard/docs_src.py
@@ -1957,7 +1957,10 @@ docs_src = {
         'summary': 'Add new asset to the tenant',
         'description': 'Add new asset to the tenant. \n `Note:` If an asset with the same slug already exists, the '
         'existing record will be updated with the new file instead of creating a duplicate entry. The old file will '
-        '**not** be deleted from the storage.',
+        '**not** be deleted from the storage.\n\n'
+        '**Note:** only superusers can add assets with slugs starting with an underscore (`_`). These assets are '
+        'considered private and will not be visible to other users. This is about the record in the database, not '
+        'the asset file itself. The asset file will have it\'s own permissions according to the host that serves it',
         'body': serializers.TenantAssetSerializer(),
         'responses': responses(
             overrides={
@@ -1971,7 +1974,10 @@ docs_src = {
         'summary': 'List all asset',
         'description': 'Retrieve a list of all assets. System admins can view all assets, while other users can only '
         'view assets associated with their accessible tenant. Use the Tenant ID filter to narrow down the results to a '
-        'specific tenant.',
+        'specific tenant.\n\n'
+        '**Note:** assets with slugs starting with an underscore (`_`) are considered private and will be visible only '
+        'to system admins. This is about the record in the database, not the asset file itself. The asset file will '
+        'have it\'s own permissions according to the host that serves it',
         'parameters': [
             query_parameter(
                 'tenant_id',

--- a/futurex_openedx_extensions/dashboard/urls.py
+++ b/futurex_openedx_extensions/dashboard/urls.py
@@ -19,7 +19,7 @@ roles_router.register(r'user_roles', views.UserRolesManagementView, basename='us
 export_router = DefaultRouter()
 export_router.register(r'tasks', views.DataExportManagementView, basename='data-export-tasks')
 tenant_assets_router = DefaultRouter()
-tenant_assets_router.register(r'tenant_assets', views.CourseAssetsManagementView, basename='tenant-assets')
+tenant_assets_router.register(r'tenant_assets', views.TenantAssetsManagementView, basename='tenant-assets')
 
 urlpatterns = [
     re_path(r'^api/fx/accessible/v1/info/$', views.AccessibleTenantsInfoView.as_view(), name='accessible-info'),

--- a/futurex_openedx_extensions/dashboard/views.py
+++ b/futurex_openedx_extensions/dashboard/views.py
@@ -1642,10 +1642,10 @@ class FileUploadView(FXViewRoleInfoMixin, APIView):
         )
 
 
-@docs('CourseAssetsManagementView.create')
-@docs('CourseAssetsManagementView.list')
+@docs('TenantAssetsManagementView.create')
+@docs('TenantAssetsManagementView.list')
 @exclude_schema_for('retrieve', 'update', 'partial_update', 'destroy')
-class CourseAssetsManagementView(FXViewRoleInfoMixin, viewsets.ModelViewSet):  # pylint: disable=too-many-ancestors
+class TenantAssetsManagementView(FXViewRoleInfoMixin, viewsets.ModelViewSet):  # pylint: disable=too-many-ancestors
     """View to list and retrieve course assets."""
     authentication_classes = default_auth_classes
     permission_classes = [FXHasTenantAllCoursesAccess]

--- a/futurex_openedx_extensions/dashboard/views.py
+++ b/futurex_openedx_extensions/dashboard/views.py
@@ -98,6 +98,7 @@ from futurex_openedx_extensions.helpers.tenants import (
     create_new_tenant_config,
     delete_draft_tenant_config,
     get_accessible_config_keys,
+    get_all_tenants_info,
     get_draft_tenant_config,
     get_excluded_tenant_ids,
     get_tenant_config,
@@ -1665,9 +1666,18 @@ class TenantAssetsManagementView(FXViewRoleInfoMixin, viewsets.ModelViewSet):  #
 
     def get_queryset(self) -> QuerySet:
         """Get the list of user uploaded files."""
-        return TenantAsset.objects.filter(
-            tenant__id__in=self.request.fx_permission_info['view_allowed_tenant_ids_full_access']
-        )
+        is_staff_user = self.request.fx_permission_info['is_system_staff_user']
+        accessible_tenant_ids = self.request.fx_permission_info['view_allowed_tenant_ids_full_access']
+        if is_staff_user:
+            template_tenant_id = get_all_tenants_info()['template_tenant']['tenant_id']
+            if template_tenant_id:
+                accessible_tenant_ids.append(template_tenant_id)
+
+        result = TenantAsset.objects.filter(tenant__id__in=accessible_tenant_ids)
+        if not is_staff_user:
+            result = result.exclude(slug__startswith='_')
+
+        return result
 
 
 class SetThemePreviewCookieView(APIView):

--- a/futurex_openedx_extensions/helpers/admin.py
+++ b/futurex_openedx_extensions/helpers/admin.py
@@ -331,7 +331,7 @@ class ConfigAccessControlForm(forms.ModelForm):
         fields = '__all__'
 
     def clean_path(self) -> str:
-        """Validates path with default tenant config."""
+        """Validates path with template tenant config."""
         key_path = self.data['path']
 
         if not key_path:
@@ -341,7 +341,7 @@ class ConfigAccessControlForm(forms.ModelForm):
             raise forms.ValidationError('Key path must not contain spaces.')
 
         try:
-            default_config = TenantConfig.objects.get(route__domain=settings.FX_DEFAULT_TENANT_SITE).lms_configs
+            template_config = TenantConfig.objects.get(route__domain=settings.FX_TEMPLATE_TENANT_SITE).lms_configs
         except TenantConfig.DoesNotExist as exc:
             raise forms.ValidationError('Unable to update path as default TenantConfig not found.') from exc
 
@@ -354,7 +354,7 @@ class ConfigAccessControlForm(forms.ModelForm):
         if any(invalid_chars_pattern.search(part) for part in path_parts):
             raise forms.ValidationError('Key path parts must include only alphanumeric characters and underscores.')
 
-        data_pointer = default_config
+        data_pointer = template_config
         found_path = []
         for part in path_parts:
             try:

--- a/futurex_openedx_extensions/helpers/settings/common_production.py
+++ b/futurex_openedx_extensions/helpers/settings/common_production.py
@@ -78,9 +78,9 @@ def plugin_settings(settings: Any) -> None:
     )
 
     # Default Tenant site
-    settings.FX_DEFAULT_TENANT_SITE = getattr(
+    settings.FX_TEMPLATE_TENANT_SITE = getattr(
         settings,
-        'FX_DEFAULT_TENANT_SITE',
+        'FX_TEMPLATE_TENANT_SITE',
         'template.futurex.sa',
     )
 

--- a/futurex_openedx_extensions/helpers/tenants.py
+++ b/futurex_openedx_extensions/helpers/tenants.py
@@ -358,7 +358,7 @@ def generate_tenant_config(sub_domain: str, platform_name: str) -> dict:
     :rtype: dict
     """
     try:
-        default_config = TenantConfig.objects.get(route__domain=settings.FX_DEFAULT_TENANT_SITE)
+        default_config = TenantConfig.objects.get(route__domain=settings.FX_TEMPLATE_TENANT_SITE)
         config_lms_dict = json.dumps(default_config.lms_configs)
         config_lms_dict = config_lms_dict.replace('{{platform_name}}', platform_name)
         config_lms_dict = config_lms_dict.replace('{{sub_domain}}', sub_domain)
@@ -366,7 +366,7 @@ def generate_tenant_config(sub_domain: str, platform_name: str) -> dict:
     except TenantConfig.DoesNotExist as exc:
         raise FXCodedException(
             code=FXExceptionCodes.TENANT_NOT_FOUND,
-            message=f'Default TenantConfig not found! default site: ({settings.FX_DEFAULT_TENANT_SITE})',
+            message=f'Default TenantConfig not found! default site: ({settings.FX_TEMPLATE_TENANT_SITE})',
         ) from exc
 
 

--- a/futurex_openedx_extensions/helpers/tenants.py
+++ b/futurex_openedx_extensions/helpers/tenants.py
@@ -137,6 +137,12 @@ def get_all_tenants_info() -> Dict[str, str | dict | List[int]]:
         tenant_by_site[lms_base_no_port] = tenant['id']
         tenant_by_site[lms_base] = tenant['id']
 
+    try:
+        template_tenant = TenantConfig.objects.get(external_key=settings.FX_TEMPLATE_TENANT_SITE)
+    except TenantConfig.DoesNotExist:
+        template_tenant = None
+        logger.error('CONFIGURATION ERROR: Template tenant not found! (%s)', settings.FX_TEMPLATE_TENANT_SITE)
+
     return {
         'tenant_ids': tenant_ids,
         'sites': {
@@ -161,6 +167,10 @@ def get_all_tenants_info() -> Dict[str, str | dict | List[int]]:
         },
         'tenant_by_site': tenant_by_site,
         'sso_sites': sso_sites,
+        'template_tenant': {
+            'tenant_id': template_tenant.id if template_tenant else None,
+            'tenant_site': settings.FX_TEMPLATE_TENANT_SITE if template_tenant else None,
+        },
     }
 
 

--- a/test_utils/test_settings_common.py
+++ b/test_utils/test_settings_common.py
@@ -129,7 +129,7 @@ FX_SSO_INFO = {
     },
 }
 
-FX_DEFAULT_TENANT_SITE = 'default.example.com'
+FX_TEMPLATE_TENANT_SITE = 'default.example.com'
 FX_TENANTS_BASE_DOMAIN = 'local.overhang.io'
 
 FX_DISABLE_CONFIG_VALIDATIONS = False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ import pytest
 from cms.djangoapps.course_creators.models import CourseCreator
 from common.djangoapps.student.models import CourseAccessRole, CourseEnrollment, UserSignupSource
 from custom_reg_form.models import ExtraInfo
+from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.sites.models import Site
 from django.core.cache import cache
@@ -122,6 +123,17 @@ def draft_configs(base_data):  # pylint: disable=unused-argument, redefined-oute
             ))
             revision_id += 1
     return result
+
+
+@pytest.fixture
+def template_tenant(base_data):  # pylint: disable=unused-argument, redefined-outer-name
+    """Fixture to create a template tenant."""
+    assert settings.FX_TEMPLATE_TENANT_SITE, 'FX_TEMPLATE_TENANT_SITE setting is not set'
+    assert TenantConfig.objects.filter(external_key=settings.FX_TEMPLATE_TENANT_SITE).count() == 0
+    tenant4 = TenantConfig.objects.get(id=4)
+    tenant4.external_key = settings.FX_TEMPLATE_TENANT_SITE
+    tenant4.save()
+    return tenant4
 
 
 @pytest.fixture(scope='session')


### PR DESCRIPTION
## Description:

Special access is two things:

1. Only system-staff users will be able to see/edit assets with slugs that start with an underscore `_`. This will make it easy to manage special assets for tenants without the probability of accidental update/deletion of those assets
2. Only system-staff users will be able to edit assets for the template tenant even though it's not listed in the accessible tenants. This will allow adding special assets that are not tenant dependent for any reason

**Note:** we're talking about the asset record in the database, not the asset file itself. The asset file will have it's own permissions according to the host that serves it

### Related Issue:
