### PR TITLE
feat: enable theme-preview for other themes

### DIFF
--- a/futurex_openedx_extensions/dashboard/middlewares.py
+++ b/futurex_openedx_extensions/dashboard/middlewares.py
@@ -1,0 +1,20 @@
+"""Middlewares"""
+from typing import Any
+
+from django.utils.deprecation import MiddlewareMixin
+from eox_theming.edxapp_wrapper.models import get_openedx_site_theme_model
+
+
+class FutureXThemePreviewMiddleware(MiddlewareMixin):  # pylint: disable=too-few-public-methods
+    """This Middleware should run after the EoxThemeMiddleware to ensure that the preview theme is set correctly."""
+    def process_request(self, request: Any) -> None:  # pylint: disable=no-self-use
+        """Set the request's 'site_theme' if `theme-preview` cookie is set."""
+        if request.COOKIES.get('theme-preview') != 'yes':
+            return
+
+        current_theme = get_openedx_site_theme_model()(
+            site_id=1,
+            theme_dir_name='indigo',
+        )
+        current_theme.id = 1
+        request.site_theme = current_theme

--- a/test_utils/edx_platform_mocks_shared/eox_theming/edxapp_wrapper/models.py
+++ b/test_utils/edx_platform_mocks_shared/eox_theming/edxapp_wrapper/models.py
@@ -1,0 +1,2 @@
+"""edx-platform Mocks"""
+from fake_models.functions import get_openedx_site_theme_model  # pylint: disable=unused-import

--- a/test_utils/edx_platform_mocks_shared/fake_models/functions.py
+++ b/test_utils/edx_platform_mocks_shared/fake_models/functions.py
@@ -65,3 +65,16 @@ def add_users(caller, role, *users):  # pylint: disable=unused-argument
 def render(request, template):  # pylint: disable=unused-argument
     """render Mock"""
     return HttpResponse()
+
+
+def get_openedx_site_theme_model():
+    """get_openedx_site_theme_model Mock"""
+    class SiteThemeMock:  # pylint: disable=too-few-public-methods
+        """Mock class for SiteTheme"""
+        def __init__(self, site_id: int, theme_dir_name: str) -> None:
+            """Initialize the mock with site_id and theme_dir_name."""
+            self.site_id = site_id
+            self.theme_dir_name = theme_dir_name
+            self.id = -1  # pylint: disable=invalid-name
+
+    return SiteThemeMock

--- a/tests/test_dashboard/test_middlewares.py
+++ b/tests/test_dashboard/test_middlewares.py
@@ -1,0 +1,41 @@
+"""Tests for middlewares."""
+import pytest
+from django.test import RequestFactory
+
+from futurex_openedx_extensions.dashboard.middlewares import FutureXThemePreviewMiddleware
+
+
+@pytest.fixture
+def request_factory():
+    return RequestFactory()
+
+
+@pytest.fixture
+def middleware():
+    return FutureXThemePreviewMiddleware(get_response=lambda request: None)
+
+
+def test_process_request_with_theme_preview_cookie(
+    request_factory, middleware,
+):  # pylint: disable=redefined-outer-name
+    """Verify that the middleware sets the site_theme when the theme-preview cookie is set to `yes`."""
+    request = request_factory.get('/')
+    request.COOKIES['theme-preview'] = 'yes'
+    assert not hasattr(request, 'site_theme')
+
+    middleware.process_request(request)
+
+    assert hasattr(request, 'site_theme')
+    assert request.site_theme.site_id == 1
+    assert request.site_theme.theme_dir_name == 'indigo'
+
+
+def test_process_request_without_theme_preview_cookie(
+    request_factory, middleware,
+):  # pylint: disable=redefined-outer-name
+    """Verify that the middleware does not set the site_theme when the theme-preview cookie is not set."""
+    request = request_factory.get('/')
+
+    middleware.process_request(request)
+
+    assert not hasattr(request, 'site_theme')


### PR DESCRIPTION
## Description:

feat: enable theme-preview for other themes. if the theme of the tenant is not set to `indigo` yet, then preview will still work!

### Related Issue:
  - #313
