### PR TITLE
feat: add payment statistics API endpoint

### DIFF
--- a/docs/concepts/index.rst
+++ b/docs/concepts/index.rst
@@ -1,2 +1,7 @@
 Concepts
 ########
+
+.. toctree::
+   :maxdepth: 2
+
+   payment_statistics

--- a/docs/concepts/payment_statistics.rst
+++ b/docs/concepts/payment_statistics.rst
@@ -1,0 +1,87 @@
+Payment Statistics
+==================
+
+This document explains the mathematical logic behind the payment statistics provided by the dashboard API.
+
+Overview
+--------
+
+The payment statistics module calculates key performance indicators (KPIs) for sales within a specified date range. The data is sourced from the ``zeitlabs_payments`` application, specifically the ``Cart`` and ``CartItem`` models.
+
+Metrics
+-------
+
+The following metrics are calculated:
+
+1. **Total Sales**
+2. **Number of Orders**
+3. **Average Order Value (AOV)**
+
+Mathematical Definitions
+------------------------
+
+Let $C$ be the set of all carts such that:
+
+*   The cart status is ``PAID``.
+*   The cart's ``updated_at`` timestamp falls within the selected date range $[T_{start}, T_{end}]$.
+
+Let $I$ be the set of all cart items belonging to carts in $C$. If a course filter is applied, $I$ is restricted to items corresponding to that course.
+
+Total Sales
+~~~~~~~~~~~
+
+Total Sales is the sum of the final price of all relevant cart items.
+
+.. math::
+
+    \text{Total Sales} = \sum_{item \in I} \text{item.final\_price}
+
+Number of Orders
+~~~~~~~~~~~~~~~~
+
+The Number of Orders is the count of unique carts associated with the relevant items.
+
+.. math::
+
+    \text{Number of Orders} = |\{ \text{item.cart} \mid item \in I \}|
+
+Average Order Value (AOV)
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The Average Order Value represents the average revenue generated per order.
+
+.. math::
+
+    \text{AOV} = \frac{\text{Total Sales}}{\text{Number of Orders}}
+
+If $\text{Number of Orders} = 0$, then $\text{AOV} = 0$.
+
+Daily Breakdown
+---------------
+
+The statistics are also aggregated on a daily basis to support visualization (e.g., graphs).
+
+For each day $d$ in the range $[T_{start}, T_{end}]$:
+
+1.  **Daily Sales ($S_d$)**: Sum of ``final_price`` for items where the cart was updated on day $d$.
+2.  **Daily Orders ($O_d$)**: Count of unique carts updated on day $d$.
+3.  **Daily Average ($A_d$)**:
+
+.. math::
+
+    A_d = \frac{S_d}{O_d}
+
+Implementation Details
+----------------------
+
+The calculation is performed in ``futurex_openedx_extensions.dashboard.statistics.payments.get_payment_statistics``.
+
+*   **Filters**:
+    *   ``cart__status``: Must be ``'paid'``.
+    *   ``cart__updated_at``: Must be within the provided ``from_date`` and ``to_date``.
+    *   ``catalogue_item__item_ref_id``: (Optional) Filters by specific course ID.
+    *   **Permissions**: The query is restricted to courses accessible to the requesting user.
+
+*   **Aggregation**:
+    *   Django's ``Sum`` and ``Count`` aggregation functions are used for efficient database-level calculation.
+    *   ``TruncDay`` is used for grouping data by day.

--- a/futurex_openedx_extensions/dashboard/docs_src.py
+++ b/futurex_openedx_extensions/dashboard/docs_src.py
@@ -244,6 +244,7 @@ repeated_descriptions = {
     ' following are the available tags along with the fields they include:\n'
     '| tag | mapped fields |\n'
     '|-----|---------------|\n'
+
 }
 
 common_schemas = {
@@ -2838,6 +2839,56 @@ docs_src = {
                 404: 'Course not found or access denied.',
             },
             remove=[200],
+        ),
+    },
+
+    'PaymentStatisticsView.get': {
+        'summary': 'Get payment statistics',
+        'description': 'Get payment statistics for the given date range. '
+                       'Results are filtered by courses accessible to the user.',
+        'parameters': [
+            query_parameter(
+                'from_date',
+                str,
+                'Start date for the statistics (ISO 8601 format). Default: 30 days ago.',
+            ),
+            query_parameter(
+                'to_date',
+                str,
+                'End date for the statistics (ISO 8601 format). Default: now.',
+            ),
+            query_parameter(
+                'course_id',
+                str,
+                'Optional course ID to filter by.',
+            ),
+            query_parameter(
+                'tenant_id',
+                int,
+                'Optional tenant ID to filter by. If provided, results will be limited to this tenant.',
+            ),
+        ],
+        'responses': responses(
+            success_schema=openapi.Schema(
+                type=openapi.TYPE_OBJECT,
+                properties={
+                    'total_sales': openapi.Schema(type=openapi.TYPE_NUMBER),
+                    'orders_count': openapi.Schema(type=openapi.TYPE_INTEGER),
+                    'average_order_value': openapi.Schema(type=openapi.TYPE_NUMBER),
+                    'daily_breakdown': openapi.Schema(
+                        type=openapi.TYPE_ARRAY,
+                        items=openapi.Schema(
+                            type=openapi.TYPE_OBJECT,
+                            properties={
+                                'date': openapi.Schema(type=openapi.TYPE_STRING),
+                                'total_sales': openapi.Schema(type=openapi.TYPE_NUMBER),
+                                'orders_count': openapi.Schema(type=openapi.TYPE_INTEGER),
+                                'average_order_value': openapi.Schema(type=openapi.TYPE_NUMBER),
+                            }
+                        )
+                    ),
+                }
+            )
         ),
     },
 }

--- a/futurex_openedx_extensions/dashboard/statistics/payments.py
+++ b/futurex_openedx_extensions/dashboard/statistics/payments.py
@@ -1,0 +1,86 @@
+"""
+Payment statistics module.
+
+This module provides functions to retrieve payment statistics for courses.
+"""
+from __future__ import annotations
+
+from datetime import datetime
+from decimal import Decimal
+from typing import Any, Dict, Optional
+
+from django.db.models import Count, Sum
+from django.db.models.functions import TruncDay
+from zeitlabs_payments.models import Cart, CartItem
+
+from futurex_openedx_extensions.helpers.querysets import get_base_queryset_courses
+
+
+def get_payment_statistics(  # pylint: disable=too-many-locals
+    fx_permission_info: dict,
+    from_date: datetime,
+    to_date: datetime,
+    course_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """
+    Get payment statistics for the given date range.
+
+    :param fx_permission_info: Dictionary containing permission information
+    :param from_date: Start date for the statistics
+    :param to_date: End date for the statistics
+    :param course_id: Optional course ID to filter by
+    :return: Dictionary containing total sales, number of orders, average order value, and daily breakdown
+    """
+    accessible_courses = get_base_queryset_courses(fx_permission_info)
+
+    filters = {
+        'cart__status': Cart.Status.PAID,
+        'cart__updated_at__range': (from_date, to_date),
+        'catalogue_item__item_ref_id__in': accessible_courses.values('id'),
+    }
+
+    if course_id:
+        filters['catalogue_item__item_ref_id'] = course_id
+
+    queryset = CartItem.objects.filter(**filters)
+
+    # Aggregate overall statistics
+    overall_stats = queryset.aggregate(
+        total_sales=Sum('final_price'),
+        orders_count=Count('cart', distinct=True),
+    )
+
+    total_sales = overall_stats['total_sales'] or Decimal('0.00')
+    orders_count = overall_stats['orders_count'] or 0
+    avg_order_value = (total_sales / orders_count) if orders_count > 0 else Decimal('0.00')
+
+    # Aggregate daily statistics
+    daily_stats = (
+        queryset.annotate(day=TruncDay('cart__updated_at'))
+        .values('day')
+        .annotate(
+            daily_sales=Sum('final_price'),
+            daily_orders=Count('cart', distinct=True),
+        )
+        .order_by('day')
+    )
+
+    daily_breakdown = []
+    for entry in daily_stats:
+        daily_sales = entry['daily_sales'] or Decimal('0.00')
+        daily_orders = entry['daily_orders'] or 0
+        daily_avg = (daily_sales / daily_orders) if daily_orders > 0 else Decimal('0.00')
+
+        daily_breakdown.append({
+            'date': entry['day'].date().isoformat(),
+            'total_sales': float(daily_sales),
+            'orders_count': daily_orders,
+            'average_order_value': float(daily_avg),
+        })
+
+    return {
+        'total_sales': float(total_sales),
+        'orders_count': orders_count,
+        'average_order_value': float(avg_order_value),
+        'daily_breakdown': daily_breakdown,
+    }

--- a/futurex_openedx_extensions/dashboard/urls.py
+++ b/futurex_openedx_extensions/dashboard/urls.py
@@ -97,6 +97,8 @@ urlpatterns = [
     re_path(r'^api/fx/assets/v1/', include(tenant_assets_router.urls)),
 
     re_path(r'^api/fx/payments/v1/orders/$', views.PaymentOrdersView.as_view(), name='payments-orders'),
+    re_path(r'^api/fx/statistics/v1/payments/$', views.PaymentStatisticsView.as_view(), name='payment-statistics'),
+
 
     re_path(
         r'^api/fx/redirect/set_theme_preview/$',

--- a/futurex_openedx_extensions/helpers/admin.py
+++ b/futurex_openedx_extensions/helpers/admin.py
@@ -257,6 +257,18 @@ class CacheInvalidatorAdmin(admin.ModelAdmin):
     change_list_template = 'cache_invalidator_change_list.html'
     change_list_title = 'Cache Invalidator'
 
+    # def has_add_permission(self, request: Any) -> bool:  # pylint: disable=unused-argument
+    #     """Disable add permission for CacheInvalidator."""
+    #     return False
+
+    # def has_change_permission(self, request: Any, obj: Any = None) -> bool:  # pylint: disable=unused-argument
+    #     """Disable change permission for CacheInvalidator."""
+    #     return False
+
+    # def has_delete_permission(self, request: Any, obj: Any = None) -> bool:  # pylint: disable=unused-argument
+    #     """Disable delete permission for CacheInvalidator."""
+    #     return False
+
     def changelist_view(self, request: Any, extra_context: dict | None = None) -> Response:
         """Override the default changelist_view to add cache info."""
         now_datetime = timezone.now()

--- a/test_utils/edx_platform_mocks_shared/zeitlabs_payments/models.py
+++ b/test_utils/edx_platform_mocks_shared/zeitlabs_payments/models.py
@@ -1,15 +1,52 @@
 """fake zeitlabs_payments models"""
+# pylint: skip-file
+from django.db import models
 
 
-class Cart:  # pylint: disable=too-few-public-methods
+class Cart(models.Model):
+    """Mock Cart model"""
+    user = models.ForeignKey('auth.User', on_delete=models.CASCADE, null=True)
+    status = models.CharField(max_length=20)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    class Status:
+        """Mock Status class"""
+        PAID = 'paid'
+        PENDING = 'pending'
+
     @classmethod
     def valid_statuses(cls):
         """Return all valid status values."""
-        return ['pending', 'paid']
+        return [cls.Status.PENDING, cls.Status.PAID]
+
+    class Meta:
+        app_label = 'fake_models'
 
 
-class CatalogueItem:  # pylint: disable=too-few-public-methods
+class CatalogueItem(models.Model):
+    """Mock CatalogueItem model"""
+    item_ref_id = models.CharField(max_length=255)
+    sku = models.CharField(max_length=255, null=True)
+    type = models.CharField(max_length=255, null=True)
+    title = models.CharField(max_length=255, null=True)
+    price = models.DecimalField(max_digits=10, decimal_places=2, null=True)
+    currency = models.CharField(max_length=10, null=True)
+
     @classmethod
     def valid_item_types(cls):
         """Return all valid item types."""
         return ['paid_course', 'bulk_course']
+
+    class Meta:
+        app_label = 'fake_models'
+
+
+class CartItem(models.Model):
+    """Mock CartItem model"""
+    cart = models.ForeignKey(Cart, on_delete=models.CASCADE)
+    catalogue_item = models.ForeignKey(CatalogueItem, on_delete=models.CASCADE)
+    original_price = models.DecimalField(max_digits=10, decimal_places=2, null=True)
+    final_price = models.DecimalField(max_digits=10, decimal_places=2)
+
+    class Meta:
+        app_label = 'fake_models'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 """PyTest fixtures for tests."""
 import datetime
+import gc
 from unittest.mock import patch
 
 import pytest
@@ -346,3 +347,10 @@ def base_data(django_db_setup, django_db_blocker):  # pylint: disable=unused-arg
         _create_sites()
 
     return _base_data
+
+
+@pytest.fixture(autouse=True, scope='function')
+def gc_collect():
+    """Force garbage collection after each test to reduce memory pressure and mitigate segfaults."""
+    yield
+    gc.collect()

--- a/tests/test_dashboard/test_statistics/test_payments.py
+++ b/tests/test_dashboard/test_statistics/test_payments.py
@@ -1,0 +1,150 @@
+"""Tests for payment statistics functions"""
+from datetime import timedelta
+from decimal import Decimal
+from unittest.mock import patch
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.utils.timezone import now
+from zeitlabs_payments.models import Cart, CartItem, CatalogueItem
+
+from futurex_openedx_extensions.dashboard.statistics.payments import get_payment_statistics
+from tests.fixture_helpers import get_user1_fx_permission_info
+
+
+@pytest.mark.django_db
+# pylint: disable=too-many-instance-attributes,attribute-defined-outside-init
+class TestPaymentStatistics:
+    """Tests for get_payment_statistics"""
+
+    @pytest.fixture(autouse=True)
+    def setup_data(self, base_data):  # pylint: disable=unused-argument
+        """Setup test data"""
+        self.user = get_user_model().objects.get(id=1)
+        self.fx_permission_info = get_user1_fx_permission_info()
+
+        # Create catalogue items
+        self.item1 = CatalogueItem.objects.create(
+            sku='sku1',
+            type='paid_course',
+            title='Course 1',
+            item_ref_id='course-v1:org1+course1',
+            price=Decimal('100.00'),
+            currency='USD'
+        )
+        self.item2 = CatalogueItem.objects.create(
+            sku='sku2',
+            type='paid_course',
+            title='Course 2',
+            item_ref_id='course-v1:org2+course2',
+            price=Decimal('50.00'),
+            currency='USD'
+        )
+        self.item3 = CatalogueItem.objects.create(
+            sku='sku3',
+            type='paid_course',
+            title='Course 3',
+            item_ref_id='course-v1:org3+course3',  # Not accessible
+            price=Decimal('200.00'),
+            currency='USD'
+        )
+
+        # Create carts
+        self.cart1 = Cart.objects.create(user=self.user, status=Cart.Status.PAID)
+        Cart.objects.filter(pk=self.cart1.pk).update(updated_at=now() - timedelta(days=5))
+        CartItem.objects.create(
+            cart=self.cart1, catalogue_item=self.item1, original_price=Decimal('100.00'), final_price=Decimal('100.00')
+        )
+
+        self.cart2 = Cart.objects.create(user=self.user, status=Cart.Status.PAID)
+        Cart.objects.filter(pk=self.cart2.pk).update(updated_at=now() - timedelta(days=2))
+        CartItem.objects.create(
+            cart=self.cart2, catalogue_item=self.item2, original_price=Decimal('50.00'), final_price=Decimal('50.00')
+        )
+
+        # Cart with inaccessible item
+        self.cart3 = Cart.objects.create(user=self.user, status=Cart.Status.PAID)
+        Cart.objects.filter(pk=self.cart3.pk).update(updated_at=now() - timedelta(days=1))
+        CartItem.objects.create(
+            cart=self.cart3, catalogue_item=self.item3, original_price=Decimal('200.00'), final_price=Decimal('200.00')
+        )
+
+        # Unpaid cart
+        self.cart4 = Cart.objects.create(user=self.user, status=Cart.Status.PENDING)
+        Cart.objects.filter(pk=self.cart4.pk).update(updated_at=now())
+        CartItem.objects.create(
+            cart=self.cart4, catalogue_item=self.item1, original_price=Decimal('100.00'), final_price=Decimal('100.00')
+        )
+
+    def test_get_payment_statistics_all(self):
+        """Test getting all payment statistics"""
+        from_date = now() - timedelta(days=30)
+        to_date = now()
+
+        # Mock accessible courses to include org1 and org2 but not org3
+        patch_path = 'futurex_openedx_extensions.dashboard.statistics.payments.get_base_queryset_courses'
+        with patch(patch_path) as mock_courses:
+            mock_courses.return_value.values.return_value = [
+                'course-v1:org1+course1', 'course-v1:org2+course2'
+            ]
+
+            stats = get_payment_statistics(self.fx_permission_info, from_date, to_date)
+
+        assert stats['total_sales'] == 150.0
+        assert stats['orders_count'] == 2
+        assert stats['average_order_value'] == 75.0
+        assert len(stats['daily_breakdown']) == 2
+
+    def test_get_payment_statistics_filtered_by_course(self):
+        """Test getting payment statistics filtered by course"""
+        from_date = now() - timedelta(days=30)
+        to_date = now()
+
+        patch_path = 'futurex_openedx_extensions.dashboard.statistics.payments.get_base_queryset_courses'
+        with patch(patch_path) as mock_courses:
+            mock_courses.return_value.values.return_value = [
+                'course-v1:org1+course1', 'course-v1:org2+course2'
+            ]
+
+            stats = get_payment_statistics(
+                self.fx_permission_info, from_date, to_date, course_id='course-v1:org1+course1'
+            )
+
+        assert stats['total_sales'] == 100.0
+        assert stats['orders_count'] == 1
+        assert stats['average_order_value'] == 100.0
+        assert len(stats['daily_breakdown']) == 1
+
+    def test_get_payment_statistics_date_range(self):
+        """Test getting payment statistics with date range"""
+        from_date = now() - timedelta(days=3)
+        to_date = now()
+
+        patch_path = 'futurex_openedx_extensions.dashboard.statistics.payments.get_base_queryset_courses'
+        with patch(patch_path) as mock_courses:
+            mock_courses.return_value.values.return_value = [
+                'course-v1:org1+course1', 'course-v1:org2+course2'
+            ]
+
+            stats = get_payment_statistics(self.fx_permission_info, from_date, to_date)
+
+        # Should only include cart2 (2 days ago), cart1 is 5 days ago
+        assert stats['total_sales'] == 50.0
+        assert stats['orders_count'] == 1
+        assert stats['average_order_value'] == 50.0
+
+    def test_get_payment_statistics_no_data(self):
+        """Test getting payment statistics with no data"""
+        from_date = now() - timedelta(days=30)
+        to_date = now()
+
+        patch_path = 'futurex_openedx_extensions.dashboard.statistics.payments.get_base_queryset_courses'
+        with patch(patch_path) as mock_courses:
+            mock_courses.return_value.values.return_value = []  # No accessible courses
+
+            stats = get_payment_statistics(self.fx_permission_info, from_date, to_date)
+
+        assert stats['total_sales'] == 0.0
+        assert stats['orders_count'] == 0
+        assert stats['average_order_value'] == 0.0
+        assert len(stats['daily_breakdown']) == 0

--- a/tox.ini
+++ b/tox.ini
@@ -31,13 +31,14 @@ match-dir = (?!migrations)
 
 [pytest]
 addopts = --cov futurex_openedx_extensions --cov tests --cov-report term-missing --cov-report xml --cov-fail-under=100
-norecursedirs = .* docs requirements site-packages
+norecursedirs = .* docs requirements site-packages zeitlabs-payments
 
 [testenv]
 skip_install = true
 allowlist_externals =
     rm
 setenv =
+    PYTHONHASHSEED = 0
     redwood: DJANGO_SETTINGS_MODULE = test_settings_redwood
     redwood: PYTEST_COV_CONFIG = {toxinidir}/.coveragerc-redwood
     sumac: DJANGO_SETTINGS_MODULE = test_settings_sumac


### PR DESCRIPTION
- Add PaymentStatisticsView to provide sales metrics including total sales, order count, average order value, and daily breakdown
- Add get_payment_statistics function for aggregating payment data
- Add API documentation for the payment statistics endpoint
- Add comprehensive tests for payment statistics
- Fix duplicate test class definitions in test_views.py that were causing coverage failures (TestCoursesFeedbackView and TestLibrariesView)
- Add mock models for Cart, CartItem, and CatalogueItem for testing

## Description:

Add a brief description of the changes made in this PR.

### Related Issue:
