### PR TITLE
fix: export CSV - GCS does not support put operations

### DIFF
--- a/futurex_openedx_extensions/helpers/upload.py
+++ b/futurex_openedx_extensions/helpers/upload.py
@@ -27,19 +27,12 @@ def upload_file(storage_path: str, file: str | File, is_private: bool = False) -
     :returns uploaded file URL
     """
     if isinstance(file, str):
-        # local file to upload
         with open(file, 'rb') as f:
-            content_file = ContentFile(f.read())
-            default_storage.save(storage_path, content_file)
+            file_content = ContentFile(f.read())
     else:
-        # file object to upload
-        directory = os.path.dirname(storage_path)
-        if not default_storage.exists(directory):
-            default_storage.save(directory + '/.empty', ContentFile(''))
-        with default_storage.open(storage_path, 'wb') as f:
-            for chunk in file.chunks():
-                f.write(chunk)
-        default_storage.delete(directory + '/.empty')
+        file_content = ContentFile(file.read())
+
+    default_storage.save(storage_path, file_content)
 
     if is_private and isinstance(default_storage, S3Boto3Storage):
         default_storage.bucket.Object(storage_path).Acl().put(ACL='private')

--- a/tox.ini
+++ b/tox.ini
@@ -57,6 +57,7 @@ deps =
     redwood: -e{toxinidir}/test_utils/edx_platform_mocks_redwood
     sumac: -e{toxinidir}/test_utils/edx_platform_mocks_sumac
     teak: -e{toxinidir}/test_utils/edx_platform_mocks_teak
+    setuptools==79.0.0
 commands =
     rm -Rf {toxinidir}/test_utils/edx_platform_mocks_shared/fake_models/migrations
     rm -Rf {toxinidir}/test_utils/edx_platform_mocks_redwood/fake_models/migrations
@@ -79,6 +80,7 @@ allowlist_externals =
     rm
 deps =
     -r{toxinidir}/requirements/doc.in
+    setuptools==79.0.0
 commands =
     doc8 --ignore-path docs/_build README.rst docs
     rm -f docs/futurex_openedx_extensions.rst
@@ -94,6 +96,7 @@ deps =
     -c{toxinidir}/requirements/test-constraints-redwood.txt
     -r{toxinidir}/requirements/quality.in
     -e{toxinidir}/test_utils/edx_platform_mocks_shared
+    setuptools==79.0.0
 commands =
     flake8 futurex_openedx_extensions tests test_utils manage.py
     mypy futurex_openedx_extensions manage.py
@@ -122,5 +125,6 @@ setenv =
     DJANGO_SETTINGS_MODULE = test_settings_redwood
 deps =
     -r{toxinidir}/requirements/test.in
+    setuptools==79.0.0
 commands =
     code_annotations django_find_annotations --config_file .pii_annotations.yml --lint --report --coverage


### PR DESCRIPTION
## Description:

fix: export CSV - GCS does not support put operations

### Related Issue:
- https://zeitlabs.atlassian.net/browse/FX-155
