### PR TITLE
feat: view to serve config files (Dashboard theme uploads)

### DIFF
--- a/futurex_openedx_extensions/__init__.py
+++ b/futurex_openedx_extensions/__init__.py
@@ -1,3 +1,3 @@
 """One-line description for README and other doc files."""
 
-__version__ = '0.12.6'
+__version__ = '0.12.7'

--- a/futurex_openedx_extensions/dashboard/serializers.py
+++ b/futurex_openedx_extensions/dashboard/serializers.py
@@ -12,6 +12,7 @@ from common.djangoapps.student.models import CourseEnrollment
 from common.djangoapps.student.roles import CourseInstructorRole, CourseStaffRole
 from django.conf import settings
 from django.contrib.auth import get_user_model
+from django.urls import reverse
 from django.utils.timezone import now
 from eox_nelp.course_experience.models import FeedbackCourse
 from eox_tenant.models import TenantConfig
@@ -1355,8 +1356,12 @@ class TenantAssetSerializer(FxPermissionInfoSerializerMixin, serializers.ModelSe
         return slug
 
     def get_file_url(self, obj: TenantAsset) -> Any:  # pylint: disable=no-self-use
-        """Return file url."""
-        return obj.file.url
+        """Return the relative serve URL for this asset's current file."""
+        filename = os.path.basename(obj.file.name)
+        return reverse(
+            'fx_dashboard:tenant-asset-serve',
+            kwargs={'tenant_id': obj.tenant_id, 'filename': filename},
+        )
 
     def create(self, validated_data: dict) -> TenantAsset:
         """

--- a/futurex_openedx_extensions/dashboard/urls.py
+++ b/futurex_openedx_extensions/dashboard/urls.py
@@ -33,6 +33,7 @@ from futurex_openedx_extensions.dashboard.views.courses import (
     CoursesView,
     LibraryView,
 )
+from futurex_openedx_extensions.dashboard.views.files import TenantAssetServeView
 from futurex_openedx_extensions.dashboard.views.learners import (
     LearnerCoursesView,
     LearnerInfoView,
@@ -141,6 +142,11 @@ urlpatterns = [
     re_path(r'^api/fx/config/v1/values/$', ThemeConfigRetrieveView.as_view(), name='theme-config-values'),
     re_path(r'^api/fx/config/v1/tenant/$', ThemeConfigTenantView.as_view(), name='theme-config-tenant'),
     re_path(r'^api/fx/file/v1/upload/$', FileUploadView.as_view(), name='file-upload'),
+    re_path(
+        r'^api/fx/assets/v1/serve/(?P<tenant_id>\d+)/(?P<filename>[^/]+)$',
+        TenantAssetServeView.as_view(),
+        name='tenant-asset-serve',
+    ),
     re_path(r'^api/fx/assets/v1/', include(tenant_assets_router.urls)),
 
     re_path(r'^api/fx/payments/v1/orders/$', PaymentOrdersView.as_view(), name='payments-orders'),

--- a/futurex_openedx_extensions/dashboard/views/files.py
+++ b/futurex_openedx_extensions/dashboard/views/files.py
@@ -1,0 +1,48 @@
+"""Views for serving stored files."""
+from __future__ import annotations
+
+import mimetypes
+from typing import Any
+
+from django.conf import settings
+from django.core.files.storage import default_storage
+from django.http import FileResponse, Http404
+from rest_framework.permissions import AllowAny
+from rest_framework.views import APIView
+
+from futurex_openedx_extensions.helpers.constants import CONFIG_FILES_UPLOAD_DIR
+
+
+class TenantAssetServeView(APIView):
+    """Public endpoint that serves tenant asset files.
+
+    Only files under `{FX_DASHBOARD_STORAGE_DIR}/{tenant_id}/{CONFIG_FILES_UPLOAD_DIR}/`
+    are served. CSV exports and anything else are rejected. No authentication; meant
+    to sit behind a CDN.
+    """
+    authentication_classes: list = []
+    permission_classes = [AllowAny]
+
+    def get(self, request: Any, tenant_id: str, filename: str) -> Any:  # pylint: disable=no-self-use
+        """GET /api/fx/assets/v1/serve/<tenant_id>/<filename>"""
+        # URL regex (\d+ / [^/]+) already blocks slashes and ensures non-empty values;
+        # this guards against path travesal attacks.
+        if filename in ('.', '..'):
+            raise Http404
+
+        storage_path = '/'.join([
+            settings.FX_DASHBOARD_STORAGE_DIR.rstrip('/'),
+            tenant_id,
+            CONFIG_FILES_UPLOAD_DIR,
+            filename,
+        ])
+        if not default_storage.exists(storage_path):
+            raise Http404
+
+        content_type, _ = mimetypes.guess_type(filename)
+        response = FileResponse(
+            default_storage.open(storage_path, 'rb'),
+            content_type=content_type or 'application/octet-stream',
+        )
+        response['Cache-Control'] = 'public, max-age=86400'
+        return response

--- a/tests/test_dashboard/test_files_views.py
+++ b/tests/test_dashboard/test_files_views.py
@@ -1,0 +1,136 @@
+"""Tests for futurex_openedx_extensions.dashboard.views.files"""
+import shutil
+
+import ddt
+import pytest
+from django.conf import settings
+from django.core.files.storage import default_storage
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.urls import reverse
+from rest_framework import status as http_status
+
+from futurex_openedx_extensions.helpers import constants as cs
+from tests.test_dashboard.test_mixins import BaseTestViewMixin
+
+
+@ddt.ddt
+@pytest.mark.usefixtures('base_data')
+class TestTenantAssetServeView(BaseTestViewMixin):
+    """Tests for TenantAssetServeView"""
+    VIEW_NAME = 'fx_dashboard:tenant-asset-serve'
+
+    def setUp(self):
+        super().setUp()
+        self.tenant_id = 1
+        self.filename = 'asset-12345678.png'
+        self.file_content = b'png-bytes-here'
+        self.storage_path = '/'.join([
+            settings.FX_DASHBOARD_STORAGE_DIR.rstrip('/'),
+            str(self.tenant_id),
+            cs.CONFIG_FILES_UPLOAD_DIR,
+            self.filename,
+        ])
+        default_storage.save(self.storage_path, SimpleUploadedFile(self.filename, self.file_content))
+
+    def tearDown(self):
+        shutil.rmtree(settings.FX_DASHBOARD_STORAGE_DIR, ignore_errors=True)
+
+    def _url(self, tenant_id, filename):
+        """Reverse the serve URL for the given tenant and filename"""
+        return reverse(self.VIEW_NAME, kwargs={'tenant_id': tenant_id, 'filename': filename})
+
+    def test_serves_existing_file_anonymous(self):
+        """Anonymous request gets the file content with cache headers and no auth required"""
+        response = self.client.get(self._url(self.tenant_id, self.filename))
+        assert response.status_code == http_status.HTTP_200_OK
+        assert b''.join(response.streaming_content) == self.file_content
+        assert response['Content-Type'] == 'image/png'
+        assert response['Cache-Control'] == 'public, max-age=86400'
+
+    def test_404_when_file_missing(self):
+        """Missing file under the valid config_files prefix returns 404"""
+        response = self.client.get(self._url(self.tenant_id, 'does-not-exist.png'))
+        assert response.status_code == http_status.HTTP_404_NOT_FOUND
+
+    def test_csv_export_path_not_servable(self):
+        """A CSV in the export dir must not be reachable; URL pattern hard-codes config_files/"""
+        csv_path = '/'.join([
+            settings.FX_DASHBOARD_STORAGE_DIR.rstrip('/'),
+            str(self.tenant_id),
+            cs.CSV_EXPORT_UPLOAD_DIR,
+            'leak.csv',
+        ])
+        default_storage.save(csv_path, SimpleUploadedFile('leak.csv', b'secret data'))
+        response = self.client.get(self._url(self.tenant_id, 'leak.csv'))
+        assert response.status_code == http_status.HTTP_404_NOT_FOUND
+
+    @ddt.data('.', '..')
+    def test_dot_filename_rejected(self, filename):
+        """Literal `.` or `..` as filename slips past the regex; view's invariant guard catches it"""
+        response = self.client.get(self._url(self.tenant_id, filename))
+        assert response.status_code == http_status.HTTP_404_NOT_FOUND
+
+    def test_non_integer_tenant_id_404(self):
+        """URL regex requires \\d+ for tenant_id; non-digit yields a routing 404"""
+        response = self.client.get('/api/fx/assets/v1/serve/abc/asset.png')
+        assert response.status_code == http_status.HTTP_404_NOT_FOUND
+
+
+@pytest.mark.usefixtures('base_data')
+class TestTenantAssetUploadAndServeIntegration(BaseTestViewMixin):
+    """Round-trip: upload a tenant asset, then fetch it via the serve endpoint."""
+    upload_view_name = 'fx_dashboard:tenant-assets-list'
+
+    def tearDown(self):
+        shutil.rmtree(settings.FX_DASHBOARD_STORAGE_DIR, ignore_errors=True)
+
+    def test_upload_then_serve_round_trip(self):
+        """file_url returned by the upload view must resolve via the serve view to the same bytes"""
+        self.login_user(self.staff_user)
+        file_content = b'round-trip-bytes'
+        upload = self.client.post(
+            reverse(self.upload_view_name),
+            data={
+                'file': SimpleUploadedFile('mylogo.png', file_content, content_type='image/png'),
+                'slug': 'mylogo',
+                'tenant_id': 1,
+            },
+            format='multipart',
+        )
+        assert upload.status_code == http_status.HTTP_201_CREATED
+
+        file_url = upload.data['file_url']
+        assert file_url.startswith('/api/fx/assets/v1/serve/1/mylogo-')
+        assert file_url.endswith('.png')
+
+        self.client.logout()
+        served = self.client.get(file_url)
+        assert served.status_code == http_status.HTTP_200_OK
+        assert b''.join(served.streaming_content) == file_content
+        assert served['Content-Type'] == 'image/png'
+
+    def test_reupload_same_slug_yields_new_cachebust_url(self):
+        """Re-uploading under the same slug produces a new URL with a new uuid suffix"""
+        self.login_user(self.staff_user)
+
+        def upload(content):
+            return self.client.post(
+                reverse(self.upload_view_name),
+                data={
+                    'file': SimpleUploadedFile('logo.png', content, content_type='image/png'),
+                    'slug': 'logo',
+                    'tenant_id': 1,
+                },
+                format='multipart',
+            )
+
+        first = upload(b'v1')
+        second = upload(b'v2')
+        assert first.status_code == http_status.HTTP_201_CREATED
+        assert second.status_code == http_status.HTTP_201_CREATED
+        assert second.data['file_url'] != first.data['file_url']
+
+        self.client.logout()
+        served = self.client.get(second.data['file_url'])
+        assert served.status_code == http_status.HTTP_200_OK
+        assert b''.join(served.streaming_content) == b'v2'

--- a/tests/test_dashboard/test_views/test_views_misc.py
+++ b/tests/test_dashboard/test_views/test_views_misc.py
@@ -189,7 +189,7 @@ class TestTenantAssetsManagementView(BaseTestViewMixin):
         response = self.client.post(self.url, data, format='multipart')
         created_asset = TenantAsset.objects.get(slug='test-slug', tenant=1)
         self.assertEqual(response.status_code, http_status.HTTP_201_CREATED)
-        self.assertEqual(response.data['file_url'], default_storage.url(expected_storage_path))
+        self.assertEqual(response.data['file_url'], '/api/fx/assets/v1/serve/1/test-slug-12345678.png')
         self.assertEqual(response.data['slug'], 'test-slug')
         self.assertEqual(response.data['updated_by'], 3)
         self.assertEqual(response.data['tenant_id'], 1)
@@ -210,7 +210,7 @@ class TestTenantAssetsManagementView(BaseTestViewMixin):
             1,
             'Failed, adding another file with existing slug should not create a new db record.'
         )
-        self.assertEqual(response.data['file_url'], default_storage.url(storage_path_file2))
+        self.assertEqual(response.data['file_url'], '/api/fx/assets/v1/serve/1/test-slug-11223344.png')
         self.assertTrue(default_storage.exists(storage_path_file2))
 
     def test_create_failure(self):

--- a/tox.ini
+++ b/tox.ini
@@ -92,6 +92,7 @@ commands =
 
 [testenv:quality]
 basepython = python3.11
+uv_seed = true
 deps =
     -c{toxinidir}/requirements/test-constraints-redwood.txt
     -r{toxinidir}/requirements/quality.in


### PR DESCRIPTION
Server tenant assets, but not CSV Exports, using a python-view to circumvent GCP Storage bucket private requriements.

This works only for assets that holds no private information. These files are typically logos, SVGs, backgrounds CSS and JavaScript.

 - The file is uploaded through the asset file. 
 - A new format is returned: `/api/fx/assets/v1/serve/1/mylogo-12345678.png` which represents the following GCP object: `gs://futurex-openedx-assets-prod/fx_dashboard/1/config_files/mylogo-12345678.png`.
 - Security feature: 
   - Only integer tenant ID is accepted.
   - Only files not containing slashes are accepted. `.` and `..` are denied.
 - Follow up changes:
   - Dashboard UI: No change is needed.
   - Theme: No change is needed.


### QA
 - [x] Tests passes
 - [x] Quality checks passes
 - [ ] Tested on dev kit local machine
 - [x] Tested on staging
 - [ ] Tested on production